### PR TITLE
Add catalog metadata, make sure it gets updated

### DIFF
--- a/src/plone/app/multilingual/setuphandlers.py
+++ b/src/plone/app/multilingual/setuphandlers.py
@@ -1,4 +1,3 @@
-import logging
 from Products.CMFCore.utils import getToolByName
 # The profile id of your package:
 PROFILE_ID = 'profile-plone.app.multilingual:default'
@@ -9,17 +8,39 @@ def add_catalog_indexes(context, logger):
     '''
     catalog = getToolByName(context, 'portal_catalog')
     indexes = catalog.indexes()
+    schema = catalog.schema()
     wanted = (('Language', 'FieldIndex'), ('TranslationGroup', 'FieldIndex'))
 
     indexables = []
+    metadata = []
     for (name, meta_type) in wanted:
         if meta_type and name not in indexes:
             catalog.addIndex(name, meta_type)
             indexables.append(name)
             logger.info('Added %s for field %s.', meta_type, name)
-    if len(indexables) > 0:
+        if name not in schema:
+            catalog.addColumn(name)
+            metadata.append(name)
+            logger.info('Added catalog metadata column for field %s.' % name)
+    if len(indexables) > 0 or len(metadata) > 0:
         logger.info('Indexing new indexes %s.', ', '.join(indexables))
-        catalog.manage_reindexIndex(ids=indexables)
+        # We don't call catalog.manage_reindexIndex(ids=indexables)
+        # because that method will not update the metadata.
+        # Therefore the code of manage_reindexIndex is copied below, but
+        # update_metadata is set to True
+        paths = catalog._catalog.uids.keys()
+        for p in paths:
+            obj = catalog.resolve_path(p)
+            if obj is None:
+                obj = catalog.resolve_url(p, context.REQUEST)
+            if obj is None:
+                logger.error(
+                    'reindexIndex could not resolve an object from the uid '
+                    '%r.' % p)
+            else:
+                # Here we explicitly want to also update the metadata
+                catalog.catalog_object(
+                    obj, p, idxs=indexables, update_metadata=1)
 
 
 def setup_various(context):


### PR DESCRIPTION
Follow-up for the following 3 pull requests:
plone/plone.multilingual/pull/4
plone/archetypes.multilingual/pull/5
plone/plone.multilingualbehavior/pull/2

Since the 2 new indexes are already added here in setuphandlers, we might as well also add the catalog metadata.

Also, if we need to reindex content (because new indexes or metadata columns have been addded), make sure that the catalog metadata gets updated too. Sadly, manage_reindexIndex sets update_metadata hard-coded to False, without the possibility to pass this parameter. Therefore I copied the relevant lines from this method to the setuphandlers code.
