### PR TITLE
Fix translation views so that the correct from and to languages are show...

### DIFF
--- a/src/plone/app/multilingual/browser/templates/add-form-is-translation.pt
+++ b/src/plone/app/multilingual/browser/templates/add-form-is-translation.pt
@@ -6,7 +6,7 @@
       i18n:translate="add-form-is-translation">
     This object is going to be a translation to <span tal:replace="view/language"></span> from: 
     <ul>
-        <li tal:repeat="origin view/origin"><a href="#" class="link-overlay" tal:attributes="href origin/getURL"> <span tal:content="origin/language"></span> <span tal:content="origin/Title"></span></a></li>
+        <li tal:repeat="origin view/origin"><a href="#" class="link-overlay" tal:attributes="href origin/getURL"> <span tal:content="origin/Language"></span> <span tal:content="origin/Title"></span></a></li>
     </ul>
     <span i18n:domain="plone.app.multilingual" i18n:translate="create-object-without-translation"
           tal:define="url_quote nocall:modules/Products.PythonScripts.standard/url_quote;

--- a/src/plone/app/multilingual/browser/templates/at_babel_view.pt
+++ b/src/plone/app/multilingual/browser/templates/at_babel_view.pt
@@ -14,7 +14,7 @@
               fieldsets python:[key for key in schematas.keys() if (schematas[key].editableFields(here, visible_only=True))];
               errors python:request.get('errors', {})">
 
-          <div id="view_language" tal:content="context/language">
+          <div id="view_language" tal:content="context/Language">
           </div>
 
           <tal:fieldsets define="sole_fieldset python:len(fieldsets)==1"

--- a/src/plone/app/multilingual/browser/utils.py
+++ b/src/plone/app/multilingual/browser/utils.py
@@ -130,7 +130,12 @@ class BabelUtils(BrowserView):
 
     def current_language_name(self):
         """ Get the current language native name """
-        adapted = ILanguage(self.context)
+        if getToolByName(self.context, 'portal_factory').isTemporary(self.context):
+            # We're in Archetypes mode and inside a portal_factory, get the
+            # current language from the parent instead
+            adapted = ILanguage(self.context.__parent__)
+        else:
+            adapted = ILanguage(self.context)
         lang_code = adapted.get_language()
         util = getUtility(IContentLanguageAvailability)
         data = util.getLanguages(True)

--- a/src/plone/app/multilingual/browser/viewlets.py
+++ b/src/plone/app/multilingual/browser/viewlets.py
@@ -88,11 +88,11 @@ class addFormATIsATranslationViewlet(ViewletBase):
 
     def update(self):
         """ It's only for AT on factory so we check """
-        if self.context.portal_factory.isTemporary(self.context):
+        if getToolByName(self.context, 'portal_factory').isTemporary(self.context):
             sdm = self.context.session_data_manager
             session = sdm.getSessionData(create=True)
             if ITranslatable.providedBy(self.context):
-                self.lang = ILanguage(self.context).get_language()
+                self.lang = ILanguage(self.context.__parent__).get_language()
             else:
                 self.lang = 'NaN'
             if 'tg' in session.keys():


### PR DESCRIPTION
Fix done at the Plone Arnhem Sprint for issue #80 where the translation view shows the wrong from an to languages when working with Archetypes content. 

@bloodbare. You asked to check if the changes still work with Dexterity as well. I checked the  by
- using the same patch on a clean site
- installing p.a.contenttypes 1.0, 
- convert the default site content to Dexterity,
- installing p.a.multilingual ,
- add an extra langageu, 
- do the p.a.m setup
- and translate some content.

However: when I did this the p.a.c DX Folder CT had the multilingual behaviour attached, the DX Page CT did not. So as soon as I navigated to a page I couldn't translate it or see the language switcher. Enabled the behaviour on the page CT manually and then translation pages also worked. 
