### PR TITLE
prefix matching for language independent fields from plone.autoform

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,9 @@ Changelog
 - Fix translation views so that the correct from and to languages are shown.
   [fredvd]
 
+- Fix prefix matching for language independent fields from plone.autoform
+  [huubbouma]
+
 
 1.2.1 2013-10-16
 ----------------

--- a/src/plone/app/multilingual/browser/add.py
+++ b/src/plone/app/multilingual/browser/add.py
@@ -123,12 +123,12 @@ if isDexterityInstalled:
                         self.widgets[field].addClass('languageindependent')
                 # With plone.autoform, fieldnames from additional schematas
                 # reference their schema by prefixing their fieldname
-                # with schema.__identifier__ and then a dot as a separator
+                # with a schema prefix and then a dot as a separator
                 # See autoform.txt in the autoform package
                 if '.' in field:
                     schemaname, fieldname = field.split('.')
                     for schema in self.additionalSchemata:
-                        if schemaname == schema.__identifier__ and fieldname in schema:
+                        if self.fields[field].interface == schema and fieldname in schema:
                             if ILanguageIndependentField.providedBy(\
                                 schema[fieldname]):
                                 self.widgets[field].addClass('languageindependent')

--- a/src/plone/app/multilingual/browser/edit.py
+++ b/src/plone/app/multilingual/browser/edit.py
@@ -75,12 +75,12 @@ if isDexterityInstalled:
                         self.widgets[field].addClass('languageindependent')
                 # With plone.autoform, fieldnames from additional schematas
                 # reference their schema by prefixing their fieldname
-                # with schema.__identifier__ and then a dot as a separator
+                # with a schema prefix and then a dot as a separator
                 # See autoform.txt in the autoform package
                 if '.' in field:
                     schemaname, fieldname = field.split('.')
                     for schema in self.additionalSchemata:
-                        if schemaname == schema.__identifier__ and fieldname in schema:
+                        if self.fields[field].interface == schema and fieldname in schema:
                             if ILanguageIndependentField.providedBy(\
                                 schema[fieldname]):
                                 self.widgets[field].addClass('languageindependent')


### PR DESCRIPTION
Hi PAM team,

I noticed an issue with my dexterity content type.
The prefix in the field name is not always as generic as you might think. This is the piece of code from
plone.autoform which generated the prefix:

``` python
prefix = self.getPrefix(schema)                                
if prefix and prefix in prefixes:                              
    prefix = schema.__identifier__
```

the difference is that sometimes the complete dotted name of an interface will be the prefix. Another time just the name of the schema.

Unfortunately the current unit tests don't have a custom content type / schema setup so adding a test would be way too much consuming for me.

I'm using the 1.x branch, but I'm quite positive this is also an issue on the master branch

Kinds regards,

Huub
