### PR TITLE
Translate archetype

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Fix ``archetypes.multilingual`` checkout, we have to use ``1.x`` branch
+  since we updated ``master`` to next major release.
+  [saily]
+
 - Fix Insufficient Privileges when we translate an archetype object into a none published Folder.
   [bsuttor]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Fix Insufficient Privileges when we translate an archetype object into a none published Folder.
+  [bsuttor]
+
 - Make search look in "Language Shared" too.
   https://github.com/plone/plone.app.multilingual/issues/106
   [khink]
@@ -13,9 +16,6 @@ Changelog
 
 - Fix prefix matching for language independent fields from plone.autoform
   [huubbouma]
-
-- Fix Insufficient Privileges when we translate an archetype object into a none published Folder.
-  [bsuttor]
 
 
 1.2.1 2013-10-16

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Make search look in "Lanuguage Shared" too.
+- Make search look in "Language Shared" too.
   https://github.com/plone/plone.app.multilingual/issues/106
   [khink]
 
@@ -13,6 +13,9 @@ Changelog
 
 - Fix prefix matching for language independent fields from plone.autoform
   [huubbouma]
+
+- Fix Insufficient Privileges when we translate an archetype object into a none published Folder.
+  [bsuttor]
 
 
 1.2.1 2013-10-16

--- a/src/plone/app/multilingual/browser/add.py
+++ b/src/plone/app/multilingual/browser/add.py
@@ -34,7 +34,7 @@ class AddViewTraverser(object):
             # we are not on DX content
             self.context.REQUEST.set('type', name)
             view = queryMultiAdapter((self.context, self.context.REQUEST),
-                                         name="add_at_translation")
+                                     name='add_at_translation')
             return view.__of__(self.context)
         # set the self.context to the place where it should be stored
         if not IFolderish.providedBy(self.context):

--- a/src/plone/app/multilingual/browser/add.py
+++ b/src/plone/app/multilingual/browser/add.py
@@ -32,9 +32,10 @@ class AddViewTraverser(object):
         ti = ttool.getTypeInfo(name)
         if not IDexterityFTI.providedBy(ti):
             # we are not on DX content
-            baseUrl = self.context.absolute_url()
-            url = '%s/@@add_at_translation?type=%s' % (baseUrl, name)
-            return self.request.response.redirect(url)
+            self.context.REQUEST.set('type', name)
+            view = queryMultiAdapter((self.context, self.context.REQUEST),
+                                         name="add_at_translation")
+            return view.__of__(self.context)
         # set the self.context to the place where it should be stored
         if not IFolderish.providedBy(self.context):
             self.context = self.context.__parent__

--- a/src/plone/app/multilingual/tests/robot/test_add_translation.robot
+++ b/src/plone/app/multilingual/tests/robot/test_add_translation.robot
@@ -39,6 +39,7 @@ Add translation
 
 I add new avaliable lang '${lang}'
     Go to  ${PLONE_URL}/@@language-controlpanel
+    Wait until page contains  name=form.available_languages.from
     Select From List  name=form.available_languages.from  ${lang}
     Click Element  name=from2toButton
     Click Element  name=form.actions.save

--- a/test-plone-4.x.cfg
+++ b/test-plone-4.x.cfg
@@ -132,5 +132,5 @@ setuptools-subversion = 3.1
 [sources]
 plone.multilingual = git git://github.com/plone/plone.multilingual.git pushurl=git@github.com:plone/plone.multilingual.git
 plone.multilingualbehavior =  git git://github.com/plone/plone.multilingualbehavior.git pushurl=git@github.com:plone/plone.multilingualbehavior.git
-archetypes.multilingual =  git git://github.com/plone/archetypes.multilingual.git pushurl=git@github.com:plone/archetypes.multilingual.git
+archetypes.multilingual =  git git://github.com/plone/archetypes.multilingual.git pushurl=git@github.com:plone/archetypes.multilingual.git branch=1.x
 archetypes.testcase =  git git://github.com/sneridagh/archetypes.testcase.git pushurl=git@github.com:sneridagh/archetypes.testcase.git


### PR DESCRIPTION
There was a "Insufficient Privileges" error when we translate archetype object into a none published Folder.

See
http://stackoverflow.com/questions/23109624/insufficient-privileges-plone-app-multilingual-1-x-translate-an-archetype-c

And #105 

I don't know how to add test for a archetype content type, maybe I have to add a test into archetypes.multilingual for this error ?
