### PR TITLE
Remove dependency on session

### DIFF
--- a/src/plone/app/multilingual/browser/add.py
+++ b/src/plone/app/multilingual/browser/add.py
@@ -60,6 +60,13 @@ class AddViewTraverser(object):
         self.info['portal_type'] = source.portal_type
         self.info['tg'] = ITG(source)
 
+        # If source has already been translated to this language, just redirect
+        for brain in catalog.unrestrictedSearchResults(
+                TranslationGroup=self.info['tg'],
+                Language=self.info['target_language']):
+            self.request.response.redirect(brain.getURL())
+            return u''
+
         # XXX: register this adapter on dx container and a second one for AT
         if not IDexterityContent.providedBy(source):
             # we are not on DX content, assume AT

--- a/src/plone/app/multilingual/browser/configure.zcml
+++ b/src/plone/app/multilingual/browser/configure.zcml
@@ -129,7 +129,7 @@
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       view="plone.app.controlpanel.interfaces.IPloneControlPanelView"
       manager="plone.app.layout.viewlets.interfaces.IAboveContent"
-      class=".viewlets.oneLanguageConfiguredNoticeViewlet"
+      class=".viewlets.OneLanguageConfiguredNoticeViewlet"
       template="templates/languages-notice.pt"
       layer="..interfaces.IPloneAppMultilingualInstalled"
       permission="cmf.ManagePortal"/>
@@ -140,7 +140,7 @@
       for="*"
       view="plone.dexterity.browser.add.DefaultAddView"
       manager="plone.app.layout.viewlets.interfaces.IAboveContent"
-      class=".viewlets.addFormIsATranslationViewlet"
+      class=".viewlets.AddFormIsATranslationViewlet"
       template="templates/add-form-is-translation.pt"
       layer="..interfaces.IPloneAppMultilingualInstalled"
       permission="zope.Public"/>

--- a/src/plone/app/multilingual/browser/configure.zcml
+++ b/src/plone/app/multilingual/browser/configure.zcml
@@ -129,13 +129,6 @@
       layer="..interfaces.IPloneAppMultilingualInstalled"
       permission="zope.Public"/>
 
-  <browser:page
-      name="multilingual-remove-tg-session"
-      for="*"
-      class=".helper_views.remove_tg_session"
-      permission="zope.Public"
-      layer="..interfaces.IPloneAppMultilingualInstalled"/>
-
   <!-- Universal Link -->
   <browser:page
       name="multilingual-universal-link"

--- a/src/plone/app/multilingual/browser/configure.zcml
+++ b/src/plone/app/multilingual/browser/configure.zcml
@@ -32,32 +32,6 @@
       name="addtranslation"
       factory=".add.AddViewTraverser"/>
 
-  <adapter
-      name="plone.app.multilingual.addtranslation.marker"
-      provides="plone.z3cform.fieldsets.interfaces.IFormExtender"
-      for="*
-      plone.app.multilingual.interfaces.IPloneAppMultilingualInstalled
-      plone.app.multilingual.browser.add.MultilingualAddForm"
-      factory=".add.MultilingualAddFormExtender"/>
-
-  <adapter
-      provides="z3c.form.interfaces.IDataManager"
-      for="*
-      .add.IMultilingualAddFormMarkerFieldMarker"
-      factory=".add.FauxDataManager"/>
-
-  <adapter
-      name="default"
-      provides="z3c.form.interfaces.IValue"
-      factory=".add.MultilingualAddFormTgValue"/>
-
-
-
-  <adapter
-      name="default"
-      provides="z3c.form.interfaces.IValue"
-      factory=".add.MultilingualAddFormOldLangValue"/>
-
   <browser:page
       name="add_translations"
       for="plone.app.multilingual.interfaces.ITranslatable"

--- a/src/plone/app/multilingual/browser/helper_views.py
+++ b/src/plone/app/multilingual/browser/helper_views.py
@@ -30,24 +30,6 @@ except ImportError:
     from Products.CMFPlone.interfaces.factory import IFactoryTool
 
 
-class remove_tg_session(BrowserView):
-    """ Removed the tg var from session
-    """
-
-    def __call__(self):
-        sdm = self.context.session_data_manager
-        session = sdm.getSessionData(create=True)
-        if 'tg' in session.keys():
-            del session['tg']
-        if 'old_lang' in session.keys():
-            del session['old_lang']
-
-        purl = getToolByName(self.context, 'portal_url')
-        url = self.request.get('redirect', purl())
-
-        self.request.RESPONSE.redirect(url)
-
-
 @implementer(IPublishTraverse)
 class universal_link(BrowserView):
     """ Redirects the user to the negotiated translated page

--- a/src/plone/app/multilingual/browser/menu.py
+++ b/src/plone/app/multilingual/browser/menu.py
@@ -51,6 +51,14 @@ class TranslateMenu(BrowserMenu):
             ILanguage(context).get_language() == LANGUAGE_INDEPENDENT
             or is_language_independent(context)
         )
+
+        shared_folder_url = site_url + '/folder_contents'
+        pc = getToolByName(getSite(), 'portal_catalog')
+        results = pc.unrestrictedSearchResults(
+            portal_type='LIF', Language=ILanguage(context).get_language())
+        for brain in results:
+            shared_folder_url = brain.getURL() + '/folder_contents'
+
         if not is_neutral_content and not INavigationRoot.providedBy(context):
             menu.append({
                 "title": _(
@@ -249,7 +257,7 @@ class TranslateMenu(BrowserMenu):
                     default=u"Show the language shared (neutral language) "
                             u"folder"
                 ),
-                "action": site_url + '/folder_contents',
+                "action": shared_folder_url,
                 "selected": False,
                 "icon": None,
                 "extra": {

--- a/src/plone/app/multilingual/browser/templates/add-form-is-translation.pt
+++ b/src/plone/app/multilingual/browser/templates/add-form-is-translation.pt
@@ -8,11 +8,9 @@
     <ul>
         <li tal:repeat="origin view/origin"><a href="#" class="link-overlay" tal:attributes="href origin/getURL"> <span tal:content="origin/language"></span> <span tal:content="origin/Title"></span></a></li>
     </ul>
-    <span i18n:domain="plone.app.multilingual" i18n:translate="create-object-without-translation"
-          tal:define="url_quote nocall:modules/Products.PythonScripts.standard/url_quote;
-                      returnURL python:url_quote(request.URL);">
-    If you want to create this object without being a translation press 
-    <a href="#" class="link-overlay" tal:attributes="href string:@@multilingual-remove-tg-session?redirect=${returnURL}">here</a>
+    <span i18n:domain="plone.app.multilingual" i18n:translate="create-object-without-translation">
+    If you want to create this object without being a translation press
+    <a href="#" class="link-overlay" tal:attributes="href view/returnURL">here</a>
     </span>
   </dd>
 </dl>

--- a/src/plone/app/multilingual/browser/translate.py
+++ b/src/plone/app/multilingual/browser/translate.py
@@ -74,21 +74,14 @@ class gtranslation_service_dexterity(BrowserView):
 
 
 class TranslationForm(BrowserView):
-    """ Translation Form """
+    """Translation Form
+    """
 
     def __call__(self):
         language = self.request.get('language', None)
         if language:
             context = aq_inner(self.context)
             translation_manager = ITranslationManager(context)
-            # if ILanguage(context).get_language() == LANGUAGE_INDEPENDENT:
-            #     # XXX : Why we need this ? the subscriber from pm should
-            #             maintain it
-            #     language_tool = getToolByName(context, 'portal_languages')
-            #     default_language = language_tool.getDefaultLanguage()
-            #     ILanguage(context).set_language(default_language)
-            #     translation_manager.update()
-            #     context.reindexObject()
 
             new_parent = translation_manager.add_translation_delegated(language)  # noqa
 

--- a/src/plone/app/multilingual/browser/utils.py
+++ b/src/plone/app/multilingual/browser/utils.py
@@ -35,12 +35,10 @@ class BabelUtils(BrowserView):
         portal_state = getMultiAdapter((context, request),
                                        name="plone_portal_state")
         self.portal_url = portal_state.portal_url()
-        # If there is any session tg lets use the session tg
-        sdm = self.context.session_data_manager
-        session = sdm.getSessionData(create=True)
-        if 'tg' in session.keys():
-            self.group = TranslationManager(session['tg'])
-        else:
+        # If there is any translation_info lets use it
+        try:
+            self.group = TranslationManager(request.translation_info['tg'])
+        except AttributeError:
             self.group = ITranslationManager(self.context)
 
     def getGroup(self):

--- a/src/plone/app/multilingual/browser/viewlets.py
+++ b/src/plone/app/multilingual/browser/viewlets.py
@@ -20,7 +20,7 @@ def _cache_until_catalog_change(fun, self):
     return key
 
 
-class oneLanguageConfiguredNoticeViewlet(ViewletBase):
+class OneLanguageConfiguredNoticeViewlet(ViewletBase):
     """ Notice the user that PAM is installed and only one language
         is configured.
     """
@@ -38,7 +38,7 @@ class oneLanguageConfiguredNoticeViewlet(ViewletBase):
         self.available = len(supported) <= 1
 
 
-class addFormIsATranslationViewlet(ViewletBase):
+class AddFormIsATranslationViewlet(ViewletBase):
     """ Notice the user that this add form is a translation
     """
     available = False
@@ -55,54 +55,32 @@ class addFormIsATranslationViewlet(ViewletBase):
         return u""
 
     def update(self):
-        sdm = self.context.session_data_manager
-        session = sdm.getSessionData(create=True)
+        try:
+            tg = self.request.translation_info['tg']
+        except AttributeError:
+            return
+        self.available = True
         if ITranslatable.providedBy(self.context):
             self.lang = ILanguage(self.context).get_language()
         else:
             self.lang = 'NaN'
-        if 'tg' in session.keys():
-            tg = session['tg']
-            self.available = True
-            ptool = getToolByName(self.context, 'portal_catalog')
-            query = {'TranslationGroup': tg, 'Language': 'all'}
-            results = ptool.searchResults(query)
-            self.origin = results
+        catalog = getToolByName(self.context, 'portal_catalog')
+        query = {'TranslationGroup': tg, 'Language': 'all'}
+        self.origin = catalog.searchResults(query)
 
 
-class addFormATIsATranslationViewlet(ViewletBase):
-    """ Notice the user that this add form is a translation
+class AddFormATIsATranslationViewlet(AddFormIsATranslationViewlet):
+    # XXX move this class to archetypes multilingual!
+    # btw., it is not used in here.
+    """ Notice the user that this AT add form is a translation
     """
-    available = False
-
-    def language(self):
-        return self.lang
-
-    def origin(self):
-        return self.origin
-
-    def render(self):
-        if self.available:
-            return self.index()
-        return u""
 
     def update(self):
         """ It's only for AT on factory so we check """
         factory = getToolByName(self.context, 'portal_factory', None)
-        if factory is not None and factory.isTemporary(self.context):
-            sdm = self.context.session_data_manager
-            session = sdm.getSessionData(create=True)
-            if ITranslatable.providedBy(self.context):
-                self.lang = ILanguage(self.context).get_language()
-            else:
-                self.lang = 'NaN'
-            if 'tg' in session.keys():
-                tg = session['tg']
-                self.available = True
-                ptool = getToolByName(self.context, 'portal_catalog')
-                query = {'TranslationGroup': tg, 'Language': 'all'}
-                results = ptool.searchResults(query)
-                self.origin = results
+        if factory is None or not factory.isTemporary(self.context):
+            return
+        super(AddFormIsATranslationViewlet, self).update()
 
 
 class AlternateLanguagesViewlet(ViewletBase):

--- a/src/plone/app/multilingual/dx/form.py
+++ b/src/plone/app/multilingual/dx/form.py
@@ -68,10 +68,9 @@ class ValueBase(object):
 class AddingLanguageIndependentValue(ValueBase):
     # XXX Deprecated ???
     def getTranslationUuid(self):
-        sdm = self.context.session_data_manager
-        session = sdm.getSessionData(create=True)
-        if 'tg' in session.keys():
-            return session['tg']
+        translation_info = getattr(self.request, 'translation_info', {})
+        if 'tg' in translation_info.keys():
+            return translation_info['tg']
 
     def get(self):
         uuid = self.getTranslationUuid()

--- a/src/plone/app/multilingual/locales/fi/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/fi/LC_MESSAGES/plone.app.multilingual.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "POT-Creation-Date: 2013-07-05 11:58+0000\n"
-"PO-Revision-Date: 2015-02-18 10:06+0200\n"
+"PO-Revision-Date: 2015-02-18 11:45+0200\n"
 "Last-Translator: Asko Soukka <asko.soukka@iki.fi>\n"
 "Language-Team: Finnish <https://github.com/collective>\n"
 "MIME-Version: 1.0\n"
@@ -148,7 +148,7 @@ msgstr "Lisää kielikansio kielelle ${lang_name}"
 #. Default: "Add existing content as translation"
 #: ./browser/menu.py:124
 msgid "description_add_translations"
-msgstr "Aseta olemassaoleva käännös"
+msgstr "Linkitä jokin olemassaoleva sivu tämän sivun käännnökseksi"
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
 #: ./browser/templates/migration.pt:225
@@ -168,7 +168,7 @@ msgstr "Kielet, joille tämän sivuston sisältöä tulisi kääntää"
 #. Default: "Edit with the babel_edit"
 #: ./browser/menu.py:46
 msgid "description_babel_edit"
-msgstr "Muokkaa käännösnäkymässä"
+msgstr "Muokkaa käännösnäkymässä rinnakkain toisen kieliversion kanssa"
 
 #. Default: "Babel edit ${lang_name}"
 #: ./browser/menu.py:102
@@ -253,7 +253,7 @@ msgstr ""
 #. Default: "Delete translations or remove the relations"
 #: ./browser/menu.py:143
 msgid "description_remove_translations"
-msgstr ""
+msgstr "Poista vanhoja käännöksiä tai riko käännöslinkkejä poistamatta sisältöä"
 
 #. Default: "The default language used for the content and the UI of this site."
 #: ./browser/controlpanel.py:206
@@ -268,7 +268,7 @@ msgstr ""
 #. Default: "Set or change the current content language"
 #: ./browser/menu.py:206
 msgid "description_set_language"
-msgstr ""
+msgstr "Aseta tai vaihda tämän sivun kielimääritys"
 
 #. Default: "Set the language cookie always, i.e. also when the 'set_language' request parameter is absent."
 #: ./browser/controlpanel.py:156
@@ -278,7 +278,7 @@ msgstr ""
 #. Default: "Show the language shared (neutral language) folder"
 #: ./browser/menu.py:191
 msgid "description_shared_folder"
-msgstr ""
+msgstr "Siirry kieliriippumattoman eli jaetun sisällön kansioon"
 
 #. Default: "The default language used for the content and the UI of this site."
 #: ./browser/controlpanel.py:53
@@ -298,7 +298,7 @@ msgstr ""
 #. Default: "Translate into ${lang_name}"
 #: ./browser/menu.py:71
 msgid "description_translate_into"
-msgstr "Käännä kielelle ${lang_name}"
+msgstr "Tee tästä sivustä uusi käännös kielelle ${lang_name}"
 
 #. Default: "Translation map."
 #: ./browser/templates/mmap.pt:101
@@ -308,7 +308,7 @@ msgstr "Käännöskartta"
 #. Default: "Universal Language content link"
 #: ./browser/menu.py:176
 msgid "description_universal_link"
-msgstr "Kielineutraali linkki"
+msgstr "Kieliriippumaton linkki ohjaa suoraan käyttäjän omankieliseen versioon"
 
 #. Default: "Untranslated languages from the current content"
 #: ./browser/interfaces.py:42
@@ -645,7 +645,7 @@ msgstr "Poista käännöksiä..."
 #. Default: "Set content language"
 #: ./browser/menu.py:204
 msgid "title_set_language"
-msgstr "Aseta kieli"
+msgstr "Määritä tämän sivun kieli"
 
 #. Default: "Manage translations for your content."
 #: ./browser/menu.py:224

--- a/src/plone/app/multilingual/subscriber.py
+++ b/src/plone/app/multilingual/subscriber.py
@@ -146,8 +146,6 @@ def createdEvent(obj, event):
     set_recursive_language(obj, language)
 
     request = getattr(event.object, 'REQUEST', getRequest())
-    if request and 'form.widgets.pam_old_lang' not in request.form:
-        return
     try:
         ti = request.translation_info
     except AttributeError:

--- a/src/plone/app/multilingual/testing.py
+++ b/src/plone/app/multilingual/testing.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
+from Testing import ZopeTestCase
 from email.header import Header
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
 from plone.app.multilingual.browser.setup import SetupMultilingualSite
@@ -31,6 +32,30 @@ from zope.interface import noLongerProvides
 from zope.lifecycleevent import ObjectModifiedEvent
 import plone.app.dexterity
 import plone.app.multilingual
+
+
+class Sessions(z2.Layer):
+    # DEPRECATED: Sessions layer is no longer used by plone.app.multilingual,
+    # but is preserved to prevent breaking 3rd party tests setups, which
+    # possibly depending on it.
+
+    defaultBases = (PLONE_FIXTURE,)
+
+    def setUp(self):
+        with z2.zopeApp() as app:
+            ZopeTestCase.utils.setupCoreSessions(app)
+
+    def testTearDown(self):
+        with z2.zopeApp() as app:
+            # Clean up sessions after each test
+            app.session_data_manager._p_jar.sync()
+            app.session_data_manager._getSessionDataContainer()._reset()
+
+            # Commit transaction
+            from transaction import commit
+            commit()
+
+SESSIONS_FIXTURE = Sessions()
 
 
 class PloneAppMultilingualLayer(PloneSandboxLayer):

--- a/src/plone/app/multilingual/testing.py
+++ b/src/plone/app/multilingual/testing.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
-from Testing import ZopeTestCase as ztc
 from email.header import Header
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
 from plone.app.multilingual.browser.setup import SetupMultilingualSite
@@ -34,30 +33,9 @@ import plone.app.dexterity
 import plone.app.multilingual
 
 
-class Sessions(z2.Layer):
-
-    defaultBases = (PLONE_FIXTURE,)
-
-    def setUp(self):
-        with z2.zopeApp() as app:
-            ztc.utils.setupCoreSessions(app)
-
-    def testTearDown(self):
-        with z2.zopeApp() as app:
-            # Clean up sessions after each test
-            app.session_data_manager._p_jar.sync()
-            app.session_data_manager._getSessionDataContainer()._reset()
-
-            # Commit transaction
-            from transaction import commit
-            commit()
-
-SESSIONS_FIXTURE = Sessions()
-
-
 class PloneAppMultilingualLayer(PloneSandboxLayer):
 
-    defaultBases = (SESSIONS_FIXTURE, PLONE_APP_CONTENTTYPES_FIXTURE)
+    defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
         # Configure ZCML

--- a/src/plone/app/multilingual/tests/test_form.py
+++ b/src/plone/app/multilingual/tests/test_form.py
@@ -56,6 +56,33 @@ class TestForm(unittest.TestCase):
         self.assertIn('translate_into_es', self.browser.contents)
         self.assertNotIn('translate_into_en', self.browser.contents)
 
+    def test_translation_form_prevents_translating_twice(self):
+        a_ca = createContentInContainer(
+            self.portal['ca'], 'Document', title=u"Test document")
+
+        transaction.commit()
+
+        # Translate content
+        self.browser.open(
+            a_ca.absolute_url() + '/@@create_translation?language=en')
+
+        # Save ++add++translation... URL
+        add_translation_url = self.browser.url
+
+        # Fill in translation details
+        self.browser.getControl(
+            name="form.widgets.IDublinCore.title").value = u"Test document"
+        self.browser.getControl(name="form.buttons.save").click()
+
+        self.portal._p_jar.sync()
+
+        # Revisit the saved ++add++translation... URL
+        self.browser.open(add_translation_url)
+
+        # Which should now redirect to the created translation
+        self.assertEqual(self.portal['en']['test-document'].absolute_url(),
+                         self.browser.url)
+
     def test_translation_can_be_unregistered(self):
         a_ca = createContentInContainer(
             self.portal['ca'], 'Document', title=u"Test document")

--- a/src/plone/app/multilingual/tests/test_lif.py
+++ b/src/plone/app/multilingual/tests/test_lif.py
@@ -7,6 +7,7 @@ from plone.app.multilingual.testing import PAM_FUNCTIONAL_TESTING
 from plone.app.relationfield.behavior import IRelatedItems
 from plone.dexterity.fti import DexterityFTI
 from plone.dexterity.utils import createContentInContainer
+from plone.uuid.interfaces import IUUID
 from z3c.form.interfaces import IDataManager
 from z3c.form.interfaces import IValidator
 from z3c.relationfield import RelationValue
@@ -66,7 +67,7 @@ class TestLanguageIndependentFieldOnAddTranslationForm(unittest.TestCase):
 
         # Look up the ++addtranslation++ with annotated request in place
         self.view = self.portal['ca'].restrictedTraverse(
-            '++addtranslation++Feedback'
+            '++addtranslation++' + IUUID(self.document)
         )
         self.view.update()
         self.field = self.view.form_instance.fields['mandatory_feedback'].field


### PR DESCRIPTION
This fixes #120 

But needs review. Tests should pass.

In summary:

- ``create_translation?language=XX`` redirects to new ``++addtranslation++SRC-UUID``-traverser
- traverser looks up the require translation info (tg and language) from the source and saves that info into the requets
- traverser returns add view
- translation event looks up the info from the request

