### PR TITLE
Improve createdEvent subscriber to allow overiddes in archetypes.multilingual

### DIFF
--- a/src/plone/app/multilingual/subscriber.py
+++ b/src/plone/app/multilingual/subscriber.py
@@ -119,8 +119,8 @@ def set_recursive_language(ob, language):
             set_recursive_language(child, language)
 
 
-def createdEvent(obj, event):
-    """ Subscriber to set language on the child folder
+class CreationEvent(object):
+    """Subscriber to set language on the child folder
 
     It can be a
     - IObjectRemovedEvent - don't do anything
@@ -128,38 +128,54 @@ def createdEvent(obj, event):
     - IObjectAddedEvent
     - IObjectCopiedEvent
     """
-    if IObjectRemovedEvent.providedBy(event):
-        return
 
-    # On ObjectCopiedEvent and ObjectMovedEvent aq_parent(event.object) is
-    # always equal to event.newParent.
-    parent = get_parent(event.object)
-    if ITranslatable.providedBy(parent):
-        # Normal use case
-        # We set the tg, linking
-        language = ILanguage(parent).get_language()
-        set_recursive_language(obj, language)
-        sdm = obj.session_data_manager
-        session = sdm.getSessionData()
+    def __call__(self, obj, event):
+        """Called by the event system"""
+        self.obj = obj
+        self.event = event
+
+        if IObjectRemovedEvent.providedBy(event):
+            return
+        # On ObjectCopiedEvent and ObjectMovedEvent aq_parent(event.object) is
+        # always equal to event.newParent.
+        parent = get_parent(event.object)
+        if ITranslatable.providedBy(parent):
+            # Normal use case
+            # We set the translation group, linking
+            language = ILanguage(parent).get_language()
+            set_recursive_language(obj, language)
+            self.handle_created()
+        else:
+            set_recursive_language(obj, LANGUAGE_INDEPENDENT)
+
+    @property
+    def has_pam_old_lang_in_form(self):
+        request = getattr(self.event.object, 'REQUEST', getRequest())
+        return request and 'form.widgets.pam_old_lang' not in request.form
+
+    def is_new_translation(self, session):
         portal = getSite()
         portal_factory = getToolByName(portal, 'portal_factory', None)
-
-        request = getattr(event.object, 'REQUEST', getRequest())
-        has_pam_old_lang_in_form = (
-            request and
-            'form.widgets.pam_old_lang' not in request.form
-        )
-        if (not has_pam_old_lang_in_form
+        return (not self.has_pam_old_lang_in_form
                 and 'tg' in session.keys()
                 and 'old_lang' in session.keys()
                 and (portal_factory is None
-                     or not portal_factory.isTemporary(obj))):
-            IMutableTG(obj).set(session['tg'])
-            modified(obj)
+                     or not portal_factory.isTemporary(self.obj)))
+
+    def get_session(self, obj):
+        sdm = obj.session_data_manager
+        return sdm.getSessionData()
+
+    def handle_created(self):
+        session = self.get_session(self.obj)
+        if self.is_new_translation(session):
+            IMutableTG(self.obj).set(session['tg'])
+            modified(self.obj)
             del session['tg']
-            tm = ITranslationManager(obj)
+            tm = ITranslationManager(self.obj)
             old_obj = tm.get_translation(session['old_lang'])
-            ILanguageIndependentFieldsManager(old_obj).copy_fields(obj)
+            ILanguageIndependentFieldsManager(old_obj).copy_fields(self.obj)
             del session['old_lang']
-    else:
-        set_recursive_language(obj, LANGUAGE_INDEPENDENT)
+
+
+createdEvent = CreationEvent()

--- a/src/plone/app/multilingual/subscriber.py
+++ b/src/plone/app/multilingual/subscriber.py
@@ -2,6 +2,7 @@
 from Acquisition import aq_parent
 from Products.CMFCore.interfaces import IFolderish
 from Products.CMFCore.utils import getToolByName
+from plone.app.multilingual.utils import get_parent
 from plone.app.multilingual.browser.utils import is_language_independent
 from plone.app.multilingual.interfaces import ILanguage
 from plone.app.multilingual.interfaces import ILanguageIndependentFieldsManager
@@ -132,8 +133,7 @@ def createdEvent(obj, event):
 
     # On ObjectCopiedEvent and ObjectMovedEvent aq_parent(event.object) is
     # always equal to event.newParent.
-    parent = aq_parent(event.object)
-
+    parent = get_parent(event.object)
     if ITranslatable.providedBy(parent):
         # Normal use case
         # We set the tg, linking

--- a/src/plone/app/multilingual/subscriber.py
+++ b/src/plone/app/multilingual/subscriber.py
@@ -11,6 +11,7 @@ from plone.app.multilingual.interfaces import IMutableTG
 from plone.app.multilingual.interfaces import ITranslatable
 from plone.app.multilingual.interfaces import ITranslationManager
 from plone.app.multilingual.interfaces import LANGUAGE_INDEPENDENT
+from plone.dexterity.interfaces import IDexterityContent
 from plone.uuid.interfaces import IUUID
 from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
@@ -134,7 +135,7 @@ class CreationEvent(object):
         self.obj = obj
         self.event = event
 
-        if IObjectRemovedEvent.providedBy(event):
+        if not self.is_translatable:
             return
         # On ObjectCopiedEvent and ObjectMovedEvent aq_parent(event.object) is
         # always equal to event.newParent.
@@ -147,6 +148,11 @@ class CreationEvent(object):
             self.handle_created()
         else:
             set_recursive_language(obj, LANGUAGE_INDEPENDENT)
+
+    @property
+    def is_translatable(self):
+        return (not IObjectRemovedEvent.providedBy(self.event)
+                and IDexterityContent.providedBy(self.obj))
 
     @property
     def has_pam_old_lang_in_form(self):

--- a/src/plone/app/multilingual/utils.py
+++ b/src/plone/app/multilingual/utils.py
@@ -1,0 +1,13 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from Products.CMFCore.utils import getToolByName
+
+
+def get_parent(obj):
+    portal_factory = getToolByName(obj, 'portal_factory', None)
+    if portal_factory is not None and portal_factory.isTemporary(obj):
+        # created by portal_factory
+        parent = aq_parent(aq_parent(aq_parent(aq_inner(obj))))
+    else:
+        parent = aq_parent(aq_inner(obj))
+    return parent


### PR DESCRIPTION
We currently encounter 2 problems when we try to translate archetypes content types on Plone 4.3.
 * An error with Archetypes temporary objects (portal_factory)
 * A problem with the translation group on translated objects

This PR fix the error with Archetypes temporary objects and add the possibility to overrides the createdEvent subscriber in archetypes.multilingual to fix the issue with the translation group.

We have an other PR for archetypes.multilingual

cc @bsuttor