### PR TITLE
Improve createdEvent subscriber to allow overiddes in archetypes.multilingual (2)

### DIFF
--- a/src/plone/app/multilingual/browser/add.py
+++ b/src/plone/app/multilingual/browser/add.py
@@ -70,9 +70,10 @@ class AddViewTraverser(object):
         # XXX: register this adapter on dx container and a second one for AT
         if not IDexterityContent.providedBy(source):
             # we are not on DX content, assume AT
-            baseUrl = self.context.absolute_url()
-            url = '%s/@@add_at_translation?type=%s' % (baseUrl, name)
-            return self.request.response.redirect(url)
+            self.context.REQUEST.set('type', name)
+            view = queryMultiAdapter((self.context, self.context.REQUEST),
+                                     name="add_at_translation")
+            return view.__of__(self.context)
 
         # set the self.context to the place where it should be stored
         if not IFolderish.providedBy(self.context):

--- a/src/plone/app/multilingual/browser/add.py
+++ b/src/plone/app/multilingual/browser/add.py
@@ -71,6 +71,7 @@ class AddViewTraverser(object):
         if not IDexterityContent.providedBy(source):
             # we are not on DX content, assume AT
             self.context.REQUEST.set('type', name)
+            self.context.REQUEST.set('translation_info', self.info)
             view = queryMultiAdapter((self.context, self.context.REQUEST),
                                      name="add_at_translation")
             return view.__of__(self.context)

--- a/src/plone/app/multilingual/profiles/default/metadata.xml
+++ b/src/plone/app/multilingual/profiles/default/metadata.xml
@@ -3,6 +3,5 @@
   <version>3</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
-    <dependency>profile-plone.formwidget.contenttree:default</dependency>
   </dependencies>
 </metadata>

--- a/src/plone/app/multilingual/profiles/default/metadata.xml
+++ b/src/plone/app/multilingual/profiles/default/metadata.xml
@@ -3,5 +3,6 @@
   <version>3</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
+    <dependency>profile-plone.formwidget.contenttree:default</dependency>
   </dependencies>
 </metadata>

--- a/src/plone/app/multilingual/subscriber.py
+++ b/src/plone/app/multilingual/subscriber.py
@@ -137,7 +137,7 @@ class CreationEvent(object):
         self.obj = obj
         self.event = event
 
-        if IObjectRemovedEvent.providedBy(event):
+        if not self.is_translatable:
             return
         request = getattr(event.object, 'REQUEST', getRequest())
         if not IPloneAppMultilingualInstalled.providedBy(request):
@@ -153,6 +153,11 @@ class CreationEvent(object):
             self.handle_created()
         else:
             set_recursive_language(obj, LANGUAGE_INDEPENDENT)
+
+    @property
+    def is_translatable(self):
+        return (not IObjectRemovedEvent.providedBy(self.event)
+                and IDexterityContent.providedBy(self.obj))
 
     @property
     def has_pam_old_lang_in_form(self):

--- a/src/plone/app/multilingual/subscriber.py
+++ b/src/plone/app/multilingual/subscriber.py
@@ -122,8 +122,8 @@ def set_recursive_language(ob, language):
             set_recursive_language(child, language)
 
 
-def createdEvent(obj, event):
-    """ Subscriber to set language on the child folder
+class CreationEvent(object):
+    """Subscriber to set language on the child folder
 
     It can be a
     - IObjectRemovedEvent - don't do anything
@@ -131,45 +131,57 @@ def createdEvent(obj, event):
     - IObjectAddedEvent
     - IObjectCopiedEvent
     """
-    if IObjectRemovedEvent.providedBy(event):
-        return
 
-    request = getattr(event.object, 'REQUEST', getRequest())
-    if not IPloneAppMultilingualInstalled.providedBy(request):
-        return
+    def __call__(self, obj, event):
+        """Called by the event system"""
+        self.obj = obj
+        self.event = event
 
-    # On ObjectCopiedEvent and ObjectMovedEvent aq_parent(event.object) is
-    # always equal to event.newParent.
-    parent = aq_parent(event.object)
+        if IObjectRemovedEvent.providedBy(event):
+            return
+        request = getattr(event.object, 'REQUEST', getRequest())
+        if not IPloneAppMultilingualInstalled.providedBy(request):
+            return
+        # On ObjectCopiedEvent and ObjectMovedEvent aq_parent(event.object) is
+        # always equal to event.newParent.
+        parent = get_parent(event.object)
+        if ITranslatable.providedBy(parent):
+            # Normal use case
+            # We set the translation group, linking
+            language = ILanguage(parent).get_language()
+            set_recursive_language(obj, language)
+            self.handle_created()
+        else:
+            set_recursive_language(obj, LANGUAGE_INDEPENDENT)
 
-    # special parent handling
-    if not ITranslatable.providedBy(parent):
-        set_recursive_language(obj, LANGUAGE_INDEPENDENT)
-        return
+    @property
+    def has_pam_old_lang_in_form(self):
+        request = getattr(self.event.object, 'REQUEST', getRequest())
+        return request and 'form.widgets.pam_old_lang' not in request.form
 
-    # Normal use case
-    # We set the tg, linking
-    language = ILanguage(parent).get_language()
-    set_recursive_language(obj, language)
+    def is_new_translation(self, session):
+        portal = getSite()
+        portal_factory = getToolByName(portal, 'portal_factory', None)
+        return (not self.has_pam_old_lang_in_form
+                and 'tg' in session.keys()
+                and 'old_lang' in session.keys()
+                and (portal_factory is None
+                     or not portal_factory.isTemporary(self.obj)))
 
-    request = getattr(event.object, 'REQUEST', getRequest())
-    try:
-        ti = request.translation_info
-    except AttributeError:
-        return
+    def get_session(self, obj):
+        sdm = obj.session_data_manager
+        return sdm.getSessionData()
 
-    # AT check
-    portal = getSite()
-    portal_factory = getToolByName(portal, 'portal_factory', None)
-    if (
-        not IDexterityContent.providedBy(obj)
-        and portal_factory is not None
-        and not portal_factory.isTemporary(obj)
-    ):
-        return
+    def handle_created(self):
+        session = self.get_session(self.obj)
+        if self.is_new_translation(session):
+            IMutableTG(self.obj).set(session['tg'])
+            modified(self.obj)
+            del session['tg']
+            tm = ITranslationManager(self.obj)
+            old_obj = tm.get_translation(session['old_lang'])
+            ILanguageIndependentFieldsManager(old_obj).copy_fields(self.obj)
+            del session['old_lang']
 
-    IMutableTG(obj).set(ti['tg'])
-    modified(obj)
-    tm = ITranslationManager(obj)
-    old_obj = tm.get_translation(ti['source_language'])
-    ILanguageIndependentFieldsManager(old_obj).copy_fields(obj)
+
+createdEvent = CreationEvent()

--- a/src/plone/app/multilingual/subscriber.py
+++ b/src/plone/app/multilingual/subscriber.py
@@ -17,7 +17,6 @@ from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.lifecycleevent import modified
 from zope.lifecycleevent.interfaces import IObjectRemovedEvent
-from plone.browserlayer.utils import registered_layers
 from plone.app.multilingual.interfaces import IPloneAppMultilingualInstalled
 
 

--- a/src/plone/app/multilingual/subscriber.py
+++ b/src/plone/app/multilingual/subscriber.py
@@ -2,6 +2,7 @@
 from Acquisition import aq_parent
 from Products.CMFCore.interfaces import IFolderish
 from Products.CMFCore.utils import getToolByName
+from plone.app.multilingual.utils import get_parent
 from plone.app.multilingual.browser.utils import is_language_independent
 from Products.CMFPlone.interfaces import ILanguage
 from plone.app.multilingual.interfaces import ILanguageIndependentFieldsManager

--- a/src/plone/app/multilingual/utils.py
+++ b/src/plone/app/multilingual/utils.py
@@ -1,0 +1,13 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from Products.CMFCore.utils import getToolByName
+
+
+def get_parent(obj):
+    portal_factory = getToolByName(obj, 'portal_factory', None)
+    if portal_factory is not None and portal_factory.isTemporary(obj):
+        # created by portal_factory
+        parent = aq_parent(aq_parent(aq_parent(aq_inner(obj))))
+    else:
+        parent = aq_parent(aq_inner(obj))
+    return parent


### PR DESCRIPTION
Update of the PR #156 to include changes related to issue #120 and merge of PLIP 13091

We currently encounter 2 problems when we try to translate archetypes content types.

 * An error with Archetypes temporary objects (portal_factory)
 * A problem with the translation group on translated objects

This PR fix the error with Archetypes temporary objects and add the possibility to overrides the createdEvent subscriber in archetypes.multilingual to fix the issue with the translation group.

This PR was tested on Plone 5 and an other PR will be created to backport some of the changes on 2.x branch for Plone 4.3

We will have an other PR for archetypes.multilingual

cc @bsuttor