### PR TITLE
Bind multilingual-selector to navroot

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Move @@multilingual-selector registration from PloneRoot to Navigation root
+  This allows to hide language folders in nginx and to use different domains.
+  [do3cc]
 
 
 2.0.0 (2015-03-24)

--- a/src/plone/app/multilingual/browser/configure.zcml
+++ b/src/plone/app/multilingual/browser/configure.zcml
@@ -140,7 +140,7 @@
   <!-- Selector -->
   <browser:page
       name="multilingual-selector"
-      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      for="plone.app.layout.navigation.interfaces.INavigationRoot"
       class=".helper_views.selector_view"
       permission="zope.Public"
       layer="..interfaces.IPloneAppMultilingualInstalled"/>


### PR DESCRIPTION
Instead of PloneSite. PloneSite is also a nav root, so
this is a non breaking change.
the languagefolders are nav roots so with this change, one can hide the
language folders in the webserver and the languageselector keeps working.