### PR TITLE
explicitly state interface

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,8 +234,10 @@ Dexterity
 ---------
 
 Users should mark a dexterity content type as translatable by assigning a the
-multilingual behavior (``plone.app.multilingual.dx.interfaces.IDexterityTranslatable``) to the definition of the content type either via file
-system, supermodel or through the web.
+multilingual behavior
+(``plone.app.multilingual.dx.interfaces.IDexterityTranslatable``) to the
+definition of the content type either via file system, supermodel or through
+the web.
 
 
 Marking fields as language independant

--- a/README.rst
+++ b/README.rst
@@ -234,7 +234,7 @@ Dexterity
 ---------
 
 Users should mark a dexterity content type as translatable by assigning a the
-multilingual behavior to the definition of the content type either via file
+multilingual behavior (``plone.app.multilingual.dx.interfaces.IDexterityTranslatable``) to the definition of the content type either via file
 system, supermodel or through the web.
 
 


### PR DESCRIPTION
this way integrators need not search for it in the codebase