### PR TITLE
Fixed compatibility issue with Archetypes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 
 Fixes:
 
+- Fixed compatibility issue with archetypes contents: wrong URL were generated.
+  [keul]
+
 - Really don't show the Google Translate button when no API key set 
   [djowett]
 

--- a/src/plone/app/multilingual/browser/add.py
+++ b/src/plone/app/multilingual/browser/add.py
@@ -71,7 +71,7 @@ class AddViewTraverser(object):
         if not IDexterityContent.providedBy(source):
             # we are not on DX content, assume AT
             baseUrl = self.context.absolute_url()
-            url = '%s/@@add_at_translation?type=%s' % (baseUrl, name)
+            url = '%s/@@add_at_translation?type=%s' % (baseUrl, source.portal_type)
             return self.request.response.redirect(url)
 
         # set the self.context to the place where it should be stored


### PR DESCRIPTION
A wrong type parameter were generated.

See also https://github.com/plone/archetypes.multilingual/issues/13

NB: the same issue is on master/Plone 5 branch