### PR TITLE
Really don't show Translate button when no API key.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
+sudo: false
 language: python
+cache:
+  directories:
+  - buildout-cache
 python:
 - 2.6
 - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_script:
 script: bin/test --all -s plone.app.multilingual
 after_script:
 - gem install --version 0.8.9 faraday
+- gem install --version 2.9.2 net-ssh
 - gem install travis-artifacts
 - travis-artifacts upload --path parts/test
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 before_script:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
-script: bin/test
+script: bin/test --all -s plone.app.multilingual
 after_script:
 - gem install --version 0.8.9 faraday
 - gem install travis-artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
 - sed -ie "s#test-plone-4.x.cfg#test-plone-$PLONE_VERSION.x.cfg#" travis.cfg
 - mkdir -p buildout-cache/downloads
 - python bootstrap.py -c travis.cfg
+- bin/buildout -Nc travis.cfg annotate
 - bin/buildout -Nc travis.cfg
 before_script:
 - export DISPLAY=:99.0

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,11 @@ only need the following line::
 While archetypes is default in Plone for now, you can strip ``[archetypes]``.
 This may change in future so we recommend adding an appendix as shown above.
 
+If you want to use plone.app.multilingual with Plone 4.2, you will need to pin ``plone.formwidget.autocomplete``::
+
+    [versions]
+    plone.formwidget.autocomplete = 1.2.4
+
 
 Setup
 =====

--- a/setup.py
+++ b/setup.py
@@ -34,16 +34,16 @@ setup(name='plone.app.multilingual',
         'plone.directives.form',
         'plone.formwidget.contenttree',
         'Products.PloneLanguageTool',
-        'archetypes.multilingual',  # required while archetypes is default in Plone
+        'archetypes.multilingual < 2.0',  # required while archetypes is default in Plone
       ],
       extras_require={
           'dexterity': ['plone.multilingualbehavior'],
-          'archetypes': ['archetypes.multilingual'],
+          'archetypes': ['archetypes.multilingual < 2.0'],
           'test': [
               'plone.app.testing[robot]>=4.2.2',
               'plone.app.robotframework',
               'plone.multilingualbehavior',
-              'archetypes.multilingual',
+              'archetypes.multilingual < 2.0',
               'Products.LinguaPlone',
               'decorator',  # BBB
           ],

--- a/src/plone/app/multilingual/browser/add.py
+++ b/src/plone/app/multilingual/browser/add.py
@@ -104,11 +104,6 @@ if isDexterityInstalled:
     class MultilingualAddForm(DefaultAddForm):
         babel = ViewPageTemplateFile("templates/dexterity_edit.pt")
 
-        def gtenabled(self):
-            registry = getUtility(IRegistry)
-            settings = registry.forInterface(IMultiLanguageExtraOptionsSchema)
-            return settings.google_translation_key != ''
-
         def portal_url(self):
             portal_tool = getToolByName(self.context, 'portal_url', None)
             if portal_tool is not None:

--- a/src/plone/app/multilingual/browser/edit.py
+++ b/src/plone/app/multilingual/browser/edit.py
@@ -17,11 +17,6 @@ if isDexterityInstalled:
     class MultilingualEditForm(DefaultEditForm):
         babel = ViewPageTemplateFile("templates/dexterity_edit.pt")
 
-        def gtenabled(self):
-            registry = getUtility(IRegistry)
-            settings = registry.forInterface(IMultiLanguageExtraOptionsSchema)
-            return settings.google_translation_key != ''
-
         def languages(self):
             """ Deprecated """
             context = aq_inner(self.context)

--- a/src/plone/app/multilingual/browser/javascript/babel_helper.js
+++ b/src/plone/app/multilingual/browser/javascript/babel_helper.js
@@ -133,7 +133,7 @@
             sync_element_vertically(original_field, destination_field, padding, index === 0);
 
             // Add the google translation field
-            if ($('#gtanslate_service').attr('value') == "True" && ((original_field.find('.richtext-field, .textline-field, .text-field, .localstatic-field, .ArchetypesField-TextField').length > 0) || ($('#at-babel-edit').length>0))) {
+            if ($('#gtranslate_service_available').attr('value') == "True" && ((original_field.find('.richtext-field, .textline-field, .text-field, .localstatic-field, .ArchetypesField-TextField').length > 0) || ($('#at-babel-edit').length>0))) {
                 original_field.prepend("<div class='translator-widget' id='item_translation_" + order + "'></div>");
                 original_field.children('.translator-widget').click(function () {
                     var field = $(value).attr("rel");

--- a/src/plone/app/multilingual/browser/templates/dexterity_edit.pt
+++ b/src/plone/app/multilingual/browser/templates/dexterity_edit.pt
@@ -10,7 +10,7 @@
 
     <script src="++resource++plone.app.multilingual.javascript/babel_helper.js"></script>
     <input type="hidden" id="url_translate" value="" tal:attributes="value context/absolute_url"/>
-    <input type="hidden" id="gtanslate_service" value="" tal:attributes="value view/gtenabled"/>
+    <input type="hidden" id="gtranslate_service_available" value="" tal:attributes="value pamutils/gtenabled"/>
     <div class='cell width-8 position-0'>
         <h1 i18n:translate="heading_available_translations">Available translations for this content</h1>
         <div id="trans-selector"
@@ -47,4 +47,3 @@
     </div>
     </div>
 </div>
-

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -17,3 +17,6 @@ Pillow = 2.3.1
 decorator = 3.4.0
 hexagonit.recipe.download = 1.7
 plone.app.contenttypes = 1.0
+# Add pin for Plone 4.2 mentioned in README.rst 
+# (plone.formwidget.autocomplete 1.2.5 and plone.app.jquery 1.4.4 don't play nicely)
+plone.formwidget.autocomplete = 1.2.4

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -8,19 +8,6 @@ plone-series = 4.3
 eggs +=
     plone.app.contenttypes
 
-# Avoid referencing versions:Plone, which may not exist due to some
-# buildout extensions or other problems.
-basename =
-
-[download]
-recipe = hexagonit.recipe.download
-url = https://launchpad.net/plone/4.3/4.3.2/+download/Plone-4.3.2-UnifiedInstaller.tgz
-
-[install]
-recipe = collective.recipe.cmd
-on_install = true
-cmds = tar jxvf ${download:location}/Plone-4.3.2-UnifiedInstaller/packages/buildout-cache.tar.bz2 1>/dev/null
-
 [versions]
 # plone.app.contenttypes for Plone 4.3.x.
 Products.DateRecurringIndex = 2.0.1

--- a/travis.cfg
+++ b/travis.cfg
@@ -1,7 +1,6 @@
 [buildout]
 extends =
     https://raw.github.com/collective/buildout.plonetest/master/buildout-cache.cfg
-    https://raw.github.com/plone/plone.app.robotframework/master/versions.cfg
     test-plone-4.x.cfg
 
 parts =

--- a/travis.cfg
+++ b/travis.cfg
@@ -2,7 +2,7 @@
 extends =
     https://raw.github.com/collective/buildout.plonetest/master/buildout-cache.cfg
     https://raw.github.com/plone/plone.app.robotframework/master/versions.cfg
-    test-plone-4.3.x.cfg
+    test-plone-4.x.cfg
 
 parts =
     download


### PR DESCRIPTION
Also remove unused gtenabled() methods in add.py & edit.py - however I'm not sure whether you want to be deprecating things in utils.py - Any comments @thet?

rename hidden field `gtanslate_service` to `gtranslate_service_available` (not really nec, but the spelling was bugging me anyway).