### PR TITLE
Really don't show the Google Translate button when no API key set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Fixes:
 
 - Clarify naming of Language Independent Folders
   [djowett]
+- Really don't show the Google Translate button when no API key set [djowett]
 
 
 3.0.14 (2016-02-25)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,8 @@ New:
 
 Fixes:
 
-- *add item here*
-
+- Really don't show the Google Translate button when no API key set 
+  [djowett]
 
 3.0.15 (2016-03-01)
 -------------------
@@ -24,7 +24,7 @@ Fixes:
 
 - Clarify naming of Language Independent Folders
   [djowett]
-- Really don't show the Google Translate button when no API key set [djowett]
+
 
 
 3.0.14 (2016-02-25)

--- a/src/plone/app/multilingual/browser/add.py
+++ b/src/plone/app/multilingual/browser/add.py
@@ -120,11 +120,6 @@ class MultilingualAddForm(DefaultAddForm):
 
     group_class = MultilingualAddFormGroup
 
-    def gtenabled(self):
-        registry = getUtility(IRegistry)
-        settings = registry.forInterface(IMultiLanguageExtraOptionsSchema, prefix="plone")
-        return settings.google_translation_key != ''
-
     def portal_url(self):
         portal_tool = getToolByName(self.context, 'portal_url', None)
         if portal_tool is not None:

--- a/src/plone/app/multilingual/browser/edit.py
+++ b/src/plone/app/multilingual/browser/edit.py
@@ -16,11 +16,6 @@ class MultilingualEditForm(DefaultEditForm):
 
     babel = ViewPageTemplateFile("templates/dexterity_edit.pt")
 
-    def gtenabled(self):
-        registry = getUtility(IRegistry)
-        settings = registry.forInterface(IMultiLanguageExtraOptionsSchema, prefix="plone")
-        return settings.google_translation_key != ''
-
     def languages(self):
         """ Deprecated """
         context = aq_inner(self.context)

--- a/src/plone/app/multilingual/browser/javascript/babel_helper.js
+++ b/src/plone/app/multilingual/browser/javascript/babel_helper.js
@@ -133,7 +133,7 @@
             sync_element_vertically(original_field, destination_field, padding, index === 0);
 
             // Add the google translation field
-            if ($('#gtanslate_service').attr('value') === "True" && ((original_field.find('.richtext-field, .textline-field, .text-field, .localstatic-field, .ArchetypesField-TextField').length > 0) || ($('#at-babel-edit').length > 0))) {
+            if ($('#gtranslate_service_available').attr('value') === "True" && ((original_field.find('.richtext-field, .textline-field, .text-field, .localstatic-field, .ArchetypesField-TextField').length > 0) || ($('#at-babel-edit').length > 0))) {
                 original_field.prepend("<div class='translator-widget' id='item_translation_" + order + "'></div>");
                 original_field.children('.translator-widget').click(function () {
                     var field = $(value).attr("rel");

--- a/src/plone/app/multilingual/browser/templates/dexterity_edit.pt
+++ b/src/plone/app/multilingual/browser/templates/dexterity_edit.pt
@@ -10,7 +10,7 @@
 
     <script src="++resource++plone.app.multilingual.javascript/babel_helper.js"></script>
     <input type="hidden" id="url_translate" value="" tal:attributes="value context/absolute_url"/>
-    <input type="hidden" id="gtanslate_service" value="" tal:attributes="value view/gtenabled"/>
+    <input type="hidden" id="gtranslate_service_available" value="" tal:attributes="value pamutils/gtenabled"/>
     <div class='col-md-6'>
         <h1 i18n:translate="heading_available_translations">Available translations for this content</h1>
         <div id="trans-selector"
@@ -47,4 +47,3 @@
     </div>
     </div>
 </div>
-


### PR DESCRIPTION
fixes #184 on master

Sibling to PR's #185 for 1.x and #199 for 2.x

Also remove unused gtenabled() methods in add.py & edit.py