### PR TITLE
2.x clarify "Language Independent Folders"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Fixes:
   check if pam is installed when subscriber is used.
   [bsuttor]
 
+- Clarify naming of Language Independent Folders
+  [djowett]
+
 
 2.0.1 (2015-11-04)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -140,17 +140,24 @@ language does not exist (yet):
       translations for the current content.
 
 
-Neutral root folder support
----------------------------
+The "Media" folder - a shared "Language Independent Folder"
+-------------------------------------------------------
 
-The root language folders are used to place the tree of the correspondent
-language content. However, there are some use cases we need content that does
-not belongs to any language. For example, for assets or side resources like
-images, videos and documents. There is need to maintain a language neutral
-folder for place this kind of objects. After PAM setup, there is a special
-folder called *Language shared*. All items placed in this folder will have
-neutral as its default language and will be visible from the other root
-language folders as they were placed there.
+The root language folders are used to house the content tree for the
+corresponding language. However, there are some use cases where we need
+content that does not belong to any language. For example, for assets or side
+resources like images, videos and documents. For this reason PAM supplies a
+special Language Independent Folder to house these kind of objects.
+After PAM setup, there is a special folder called "Media", which can be
+accessed through the "Go to shared folder" item of the "Translate" menu. All
+items placed in this folder will have neutral as their default language and
+will be visible from the other root language folders as if they were placed
+there as well.
+
+Note: Language Independent Folder's have also been historically known as 
+"Neutral root folder", "language neutral folder" and 
+"language shared (folder)".  Also don't confuse Language Independent Folders 
+with Language Independent Fields
 
 
 Translation map

--- a/src/plone/app/multilingual/browser/menu.py
+++ b/src/plone/app/multilingual/browser/menu.py
@@ -250,12 +250,11 @@ class TranslateMenu(BrowserMenu):
             menu.append({
                 "title": _(
                     u"shared_folder",
-                    default=u"Go to shared folder"
+                    default=u"Go to Media folder"
                 ),
                 "description": _(
                     u"description_shared_folder",
-                    default=u"Show the language shared (neutral language) "
-                            u"folder"
+                    default=u"Show the shared Language Independent Folder"
                 ),
                 "action": shared_folder_url,
                 "selected": False,

--- a/src/plone/app/multilingual/browser/menu.py
+++ b/src/plone/app/multilingual/browser/menu.py
@@ -218,7 +218,7 @@ class TranslateMenu(BrowserMenu):
                 "selected": False,
                 "icon": None,
                 "extra": {
-                    "id": "_shared_folder",
+                    "id": "_language_folder",
                     "separator": None,
                     "class": ""
                 },

--- a/src/plone/app/multilingual/interfaces.py
+++ b/src/plone/app/multilingual/interfaces.py
@@ -20,7 +20,7 @@ class ILanguageRootFolder(Interface):
 
 
 class ILanguageIndependentFolder(Interface):
-    """ Language independent shared folder between languages
+    """ Language Independent Folder for content shared between languages
     """
 
 

--- a/src/plone/app/multilingual/locales/ca/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/ca/LC_MESSAGES/plone.app.multilingual.po
@@ -603,8 +603,9 @@ msgstr ""
 msgid "remove selected"
 msgstr "Esborrar la seleccionada"
 
-#. Default: "Go to shared folder"
-#: ./browser/menu.py:189
+#. Default: "Go to Media folder"
+#: ./browser/menu.py:251
+#, fuzzy
 msgid "shared_folder"
 msgstr "Anar a Carpeta compartida"
 
@@ -675,4 +676,3 @@ msgstr "Deslincar traduccions"
 #: ./browser/update_language_form.py:22
 msgid "update_language"
 msgstr ""
-

--- a/src/plone/app/multilingual/locales/ca/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/ca/LC_MESSAGES/plone.app.multilingual.po
@@ -275,8 +275,8 @@ msgstr ""
 msgid "description_set_language_cookie_always"
 msgstr ""
 
-#. Default: "Show the language shared (neutral language) folder"
-#: ./browser/menu.py:191
+#. Default: "Show the shared Language Independent Folder"
+#: ./browser/menu.py:255
 msgid "description_shared_folder"
 msgstr ""
 

--- a/src/plone/app/multilingual/locales/de/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/de/LC_MESSAGES/plone.app.multilingual.po
@@ -275,8 +275,8 @@ msgstr "Sprache setzen oder ändern."
 msgid "description_set_language_cookie_always"
 msgstr ""
 
-#. Default: "Show the language shared (neutral language) folder"
-#: ./browser/menu.py:191
+#. Default: "Show the shared Language Independent Folder"
+#: ./browser/menu.py:255
 msgid "description_shared_folder"
 msgstr ""
 

--- a/src/plone/app/multilingual/locales/de/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/de/LC_MESSAGES/plone.app.multilingual.po
@@ -604,8 +604,9 @@ msgstr ""
 msgid "remove selected"
 msgstr "Objekt löschen"
 
-#. Default: "Go to shared folder"
-#: ./browser/menu.py:189
+#. Default: "Go to Media folder"
+#: ./browser/menu.py:251
+#, fuzzy
 msgid "shared_folder"
 msgstr "Gehe zu 'shared'-Ordner"
 
@@ -676,4 +677,3 @@ msgstr "Verweis löschen"
 #: ./browser/update_language_form.py:22
 msgid "update_language"
 msgstr "Sprachzuweisung aktualisieren"
-

--- a/src/plone/app/multilingual/locales/es/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/es/LC_MESSAGES/plone.app.multilingual.po
@@ -275,8 +275,8 @@ msgstr ""
 msgid "description_set_language_cookie_always"
 msgstr ""
 
-#. Default: "Show the language shared (neutral language) folder"
-#: ./browser/menu.py:191
+#. Default: "Show the shared Language Independent Folder"
+#: ./browser/menu.py:255
 msgid "description_shared_folder"
 msgstr ""
 

--- a/src/plone/app/multilingual/locales/es/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/es/LC_MESSAGES/plone.app.multilingual.po
@@ -603,8 +603,9 @@ msgstr ""
 msgid "remove selected"
 msgstr ""
 
-#. Default: "Go to shared folder"
-#: ./browser/menu.py:189
+#. Default: "Go to Media folder"
+#: ./browser/menu.py:251
+#, fuzzy
 msgid "shared_folder"
 msgstr "Ir a carpeta compartida"
 
@@ -675,4 +676,3 @@ msgstr ""
 #: ./browser/update_language_form.py:22
 msgid "update_language"
 msgstr ""
-

--- a/src/plone/app/multilingual/locales/eu/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/eu/LC_MESSAGES/plone.app.multilingual.po
@@ -606,8 +606,9 @@ msgstr "Zure atariak ez du erlazio-kataloorik eta beraz, ez pausu hau ez da beha
 msgid "remove selected"
 msgstr "Aukeratutako ezabaldu"
 
-#. Default: "Go to shared folder"
-#: ./browser/menu.py:189
+#. Default: "Go to Media folder"
+#: ./browser/menu.py:251
+#, fuzzy
 msgid "shared_folder"
 msgstr "Partekatutako karpetara joan"
 
@@ -678,4 +679,3 @@ msgstr "Aukeratutako lotura desegin"
 #: ./browser/update_language_form.py:22
 msgid "update_language"
 msgstr "Hizkuntza eguneratu"
-

--- a/src/plone/app/multilingual/locales/eu/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/eu/LC_MESSAGES/plone.app.multilingual.po
@@ -278,8 +278,9 @@ msgstr "Elementu honen hizkuntza ezarri edo aldatu"
 msgid "description_set_language_cookie_always"
 msgstr "Hizkuntzaren cookiea beti ezarri, adibidez baita 'set_language' parametroa ez dagoenean ere."
 
-#. Default: "Show the language shared (neutral language) folder"
-#: ./browser/menu.py:191
+#. Default: "Show the shared Language Independent Folder"
+#: ./browser/menu.py:255
+#, fuzzy
 msgid "description_shared_folder"
 msgstr "Hizkuntzen artean partekatutako karpeta (neutrala) erakutsi"
 

--- a/src/plone/app/multilingual/locales/fi/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/fi/LC_MESSAGES/plone.app.multilingual.po
@@ -275,8 +275,9 @@ msgstr "Aseta tai vaihda tämän sivun kielimääritys"
 msgid "description_set_language_cookie_always"
 msgstr ""
 
-#. Default: "Show the language shared (neutral language) folder"
-#: ./browser/menu.py:191
+#. Default: "Show the shared Language Independent Folder"
+#: ./browser/menu.py:255
+#, fuzzy
 msgid "description_shared_folder"
 msgstr "Siirry kieliriippumattoman eli jaetun sisällön kansioon"
 

--- a/src/plone/app/multilingual/locales/fi/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/fi/LC_MESSAGES/plone.app.multilingual.po
@@ -603,8 +603,9 @@ msgstr ""
 msgid "remove selected"
 msgstr ""
 
-#. Default: "Go to shared folder"
-#: ./browser/menu.py:189
+#. Default: "Go to Media folder"
+#: ./browser/menu.py:251
+#, fuzzy
 msgid "shared_folder"
 msgstr "Siirry jaettuun kansioon"
 
@@ -675,4 +676,3 @@ msgstr ""
 #: ./browser/update_language_form.py:22
 msgid "update_language"
 msgstr "Vaihda kieltä"
-

--- a/src/plone/app/multilingual/locales/fr/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/fr/LC_MESSAGES/plone.app.multilingual.po
@@ -603,8 +603,9 @@ msgstr ""
 msgid "remove selected"
 msgstr "Supprimer les traductions sélectionnées"
 
-#. Default: "Go to shared folder"
-#: ./browser/menu.py:189
+#. Default: "Go to Media folder"
+#: ./browser/menu.py:251
+#, fuzzy
 msgid "shared_folder"
 msgstr "Aller au dossier partagé"
 
@@ -675,4 +676,3 @@ msgstr "Dé-lier la sélection"
 #: ./browser/update_language_form.py:22
 msgid "update_language"
 msgstr "Mettre à jour la langue"
-

--- a/src/plone/app/multilingual/locales/fr/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/fr/LC_MESSAGES/plone.app.multilingual.po
@@ -275,8 +275,9 @@ msgstr "Préciser ou modifier la langue actuelle du contenu"
 msgid "description_set_language_cookie_always"
 msgstr "Toujours définir le cookie de langue, c-à-d même quand le paramètre 'set_language' est absent de la requête."
 
-#. Default: "Show the language shared (neutral language) folder"
-#: ./browser/menu.py:191
+#. Default: "Show the shared Language Independent Folder"
+#: ./browser/menu.py:255
+#, fuzzy
 msgid "description_shared_folder"
 msgstr "Afficher le dossier partagé (langue neutre)"
 

--- a/src/plone/app/multilingual/locales/it/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/it/LC_MESSAGES/plone.app.multilingual.po
@@ -273,8 +273,9 @@ msgstr "Imposta o cambia la lingua corrente di questo contenuto."
 msgid "description_set_language_cookie_always"
 msgstr ""
 
-#. Default: "Show the language shared (neutral language) folder"
-#: ../browser/menu.py:242
+#. Default: "Show the shared Language Independent Folder"
+#: ./browser/menu.py:255
+#, fuzzy
 msgid "description_shared_folder"
 msgstr "Visualizza la cartella condivisa tra le lingue (in lingua neutra)"
 
@@ -596,8 +597,9 @@ msgstr ""
 msgid "remove selected"
 msgstr "Rimuovi la traduzione selezionata"
 
-#. Default: "Go to shared folder"
-#: ../browser/menu.py:238
+#. Default: "Go to Media folder"
+#: ./browser/menu.py:251
+#, fuzzy
 msgid "shared_folder"
 msgstr "Vai alla cartella condivisa"
 
@@ -668,4 +670,3 @@ msgstr "Scollega la lingua selezionata"
 #: ../browser/update_language_form.py:25
 msgid "update_language"
 msgstr "Aggiorna lingua"
-

--- a/src/plone/app/multilingual/locales/ja/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/ja/LC_MESSAGES/plone.app.multilingual.po
@@ -604,8 +604,8 @@ msgstr ""
 msgid "remove selected"
 msgstr "選択したアイテムを取り除く"
 
-#. Default: "Go to shared folder"
-#: ./browser/menu.py:189
+#. Default: "Go to Media folder"
+#: ./browser/menu.py:251
 msgid "shared_folder"
 msgstr ""
 
@@ -676,4 +676,3 @@ msgstr "選択したアイテムのリンクを取り除く"
 #: ./browser/update_language_form.py:22
 msgid "update_language"
 msgstr ""
-

--- a/src/plone/app/multilingual/locales/ja/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/ja/LC_MESSAGES/plone.app.multilingual.po
@@ -275,8 +275,8 @@ msgstr ""
 msgid "description_set_language_cookie_always"
 msgstr "言語クッキーを常に設定する（set_languageリクエストパラメータがない場合にも）"
 
-#. Default: "Show the language shared (neutral language) folder"
-#: ./browser/menu.py:191
+#. Default: "Show the shared Language Independent Folder"
+#: ./browser/menu.py:255
 msgid "description_shared_folder"
 msgstr ""
 

--- a/src/plone/app/multilingual/locales/pl/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/pl/LC_MESSAGES/plone.app.multilingual.po
@@ -275,8 +275,9 @@ msgstr "Ustaw lub zmień obecny język treści"
 msgid "description_set_language_cookie_always"
 msgstr "Ustawiaj plik cookie zawierający wybrany język zawsze, również w przypadku braku parametru ustawiającego języ w adresie url."
 
-#. Default: "Show the language shared (neutral language) folder"
-#: ./browser/menu.py:191
+#. Default: "Show the shared Language Independent Folder"
+#: ./browser/menu.py:255
+#, fuzzy
 msgid "description_shared_folder"
 msgstr "Wyświetlaj folder zawierający treść w języku neutralnym"
 

--- a/src/plone/app/multilingual/locales/pl/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/pl/LC_MESSAGES/plone.app.multilingual.po
@@ -603,8 +603,9 @@ msgstr ""
 msgid "remove selected"
 msgstr "Usuń zaznaczone"
 
-#. Default: "Go to shared folder"
-#: ./browser/menu.py:189
+#. Default: "Go to Media folder"
+#: ./browser/menu.py:251
+#, fuzzy
 msgid "shared_folder"
 msgstr "Przejdź do folderu współdzielonego"
 
@@ -675,4 +676,3 @@ msgstr "Odłącz zaznaczone"
 #: ./browser/update_language_form.py:22
 msgid "update_language"
 msgstr "Uaktualnij język"
-

--- a/src/plone/app/multilingual/locales/plone.app.multilingual.pot
+++ b/src/plone/app/multilingual/locales/plone.app.multilingual.pot
@@ -605,8 +605,8 @@ msgstr ""
 msgid "remove selected"
 msgstr ""
 
-#. Default: "Go to shared folder"
-#: ./browser/menu.py:189
+#. Default: "Go to Media folder"
+#: ./browser/menu.py:251
 msgid "shared_folder"
 msgstr ""
 
@@ -677,4 +677,3 @@ msgstr ""
 #: ./browser/update_language_form.py:22
 msgid "update_language"
 msgstr ""
-

--- a/src/plone/app/multilingual/locales/plone.app.multilingual.pot
+++ b/src/plone/app/multilingual/locales/plone.app.multilingual.pot
@@ -277,8 +277,8 @@ msgstr ""
 msgid "description_set_language_cookie_always"
 msgstr ""
 
-#. Default: "Show the language shared (neutral language) folder"
-#: ./browser/menu.py:191
+#. Default: "Show the shared Language Independent Folder"
+#: ./browser/menu.py:255
 msgid "description_shared_folder"
 msgstr ""
 

--- a/src/plone/app/multilingual/locales/sk/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/sk/LC_MESSAGES/plone.app.multilingual.po
@@ -275,8 +275,9 @@ msgstr "Nastavenie alebo zmena aktuálneho jazyka obsahu"
 msgid "description_set_language_cookie_always"
 msgstr "Vždy nastaviť jazyk v cookie, a to aj v prípade neexistencie parametra 'set_language' v URL adrese."
 
-#. Default: "Show the language shared (neutral language) folder"
-#: ./browser/menu.py:191
+#. Default: "Show the shared Language Independent Folder"
+#: ./browser/menu.py:255
+#, fuzzy
 msgid "description_shared_folder"
 msgstr "Zobraziť priečinok s obsahom v neutrálnom jazyku"
 

--- a/src/plone/app/multilingual/locales/sk/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/sk/LC_MESSAGES/plone.app.multilingual.po
@@ -603,8 +603,9 @@ msgstr ""
 msgid "remove selected"
 msgstr "Odstrániť vybrané"
 
-#. Default: "Go to shared folder"
-#: ./browser/menu.py:189
+#. Default: "Go to Media folder"
+#: ./browser/menu.py:251
+#, fuzzy
 msgid "shared_folder"
 msgstr "Choďte do zdieľanej zložky"
 
@@ -675,4 +676,3 @@ msgstr "Odstrániť odkaz na vybrané"
 #: ./browser/update_language_form.py:22
 msgid "update_language"
 msgstr "Aktualizovať jazyk"
-

--- a/src/plone/app/multilingual/locales/uk/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/uk/LC_MESSAGES/plone.app.multilingual.po
@@ -276,8 +276,9 @@ msgstr "Встановити або змінити мову даного кон�
 msgid "description_set_language_cookie_always"
 msgstr "Завжди встановлювати куку мови, тобто також, коли відсутній параметр для 'set_language' запиту"
 
-#. Default: "Show the language shared (neutral language) folder"
-#: ./browser/menu.py:191
+#. Default: "Show the shared Language Independent Folder"
+#: ./browser/menu.py:255
+#, fuzzy
 msgid "description_shared_folder"
 msgstr "Показати мову загальної (нейтральної мови) теки"
 

--- a/src/plone/app/multilingual/locales/uk/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/uk/LC_MESSAGES/plone.app.multilingual.po
@@ -604,8 +604,9 @@ msgstr "Ваш сайт не має ніякого каталогу віднош
 msgid "remove selected"
 msgstr "видалити вибране"
 
-#. Default: "Go to shared folder"
-#: ./browser/menu.py:189
+#. Default: "Go to Media folder"
+#: ./browser/menu.py:251
+#, fuzzy
 msgid "shared_folder"
 msgstr "Перейти до спільної теки"
 
@@ -676,4 +677,3 @@ msgstr "від'єднати вибрані"
 #: ./browser/update_language_form.py:22
 msgid "update_language"
 msgstr "Оновлення Мови"
-

--- a/src/plone/app/multilingual/locales/zh_CN/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/zh_CN/LC_MESSAGES/plone.app.multilingual.po
@@ -606,8 +606,8 @@ msgstr ""
 msgid "remove selected"
 msgstr "移除选择"
 
-#. Default: "Go to shared folder"
-#: ./browser/menu.py:189
+#. Default: "Go to Media folder"
+#: ./browser/menu.py:251
 msgid "shared_folder"
 msgstr ""
 
@@ -678,4 +678,3 @@ msgstr ""
 #: ./browser/update_language_form.py:22
 msgid "update_language"
 msgstr ""
-

--- a/src/plone/app/multilingual/locales/zh_CN/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/zh_CN/LC_MESSAGES/plone.app.multilingual.po
@@ -277,8 +277,8 @@ msgstr ""
 msgid "description_set_language_cookie_always"
 msgstr "总是设置语言 cookie，也即 'set_language' 请求参数不存在时。"
 
-#. Default: "Show the language shared (neutral language) folder"
-#: ./browser/menu.py:191
+#. Default: "Show the shared Language Independent Folder"
+#: ./browser/menu.py:255
 msgid "description_shared_folder"
 msgstr ""
 

--- a/src/plone/app/multilingual/locales/zh_TW/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/zh_TW/LC_MESSAGES/plone.app.multilingual.po
@@ -603,8 +603,9 @@ msgstr ""
 msgid "remove selected"
 msgstr "Objekt löschen"
 
-#. Default: "Go to shared folder"
-#: ./browser/menu.py:189
+#. Default: "Go to Media folder"
+#: ./browser/menu.py:251
+#, fuzzy
 msgid "shared_folder"
 msgstr "Gehe zu 'shared'-Ordner"
 
@@ -675,4 +676,3 @@ msgstr "Verweis löschen"
 #: ./browser/update_language_form.py:22
 msgid "update_language"
 msgstr "Sprachzuweisung aktualisieren"
-

--- a/src/plone/app/multilingual/locales/zh_TW/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/zh_TW/LC_MESSAGES/plone.app.multilingual.po
@@ -274,8 +274,8 @@ msgstr "Sprache setzen oder ändern."
 msgid "description_set_language_cookie_always"
 msgstr ""
 
-#. Default: "Show the language shared (neutral language) folder"
-#: ./browser/menu.py:191
+#. Default: "Show the shared Language Independent Folder"
+#: ./browser/menu.py:255
 msgid "description_shared_folder"
 msgstr ""
 


### PR DESCRIPTION
Clarify the naming for "language independent folders" (fix for #196 on 2.x branch). Includes updates to:

- README
- interfaces.py
- menu.py (& therefore po files)