### PR TITLE
Creating language folder(s) on installation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,11 +6,14 @@ Changelog
 
 Incompatibilities:
 
-- *add item here*
+- No more compatible with GenericSetup below 1.8.2.
+  [iham]
 
 New:
 
-- *add item here*
+- Creating language folder(s) on installation.
+  (fixes https://github.com/plone/plone.app.multilingual/issues/214)
+  [iham]
 
 Fixes:
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,14 @@
-from setuptools import setup, find_packages
-import os
+"""Setup plone.app.multilingual."""
 
-version = '3.0.16.dev0'
+import os
+from setuptools import setup, find_packages
+
+
+VERSION = '3.0.16.dev0'
 
 setup(
     name='plone.app.multilingual',
-    version=version,
+    version=VERSION,
     description="Multilingual Plone UI package, enables maintenance of "
                 "translations for both Dexterity types and Archetypes",
     long_description="\n\n".join([
@@ -32,6 +35,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'Products.CMFPlone>=5.0b1',
+        'Products.GenericSetup>=1.8.2',
         'archetypes.multilingual',
         'plone.app.registry',
         'plone.app.z3cform',

--- a/src/plone/app/multilingual/configure.zcml
+++ b/src/plone/app/multilingual/configure.zcml
@@ -147,7 +147,8 @@
       description="Install to enable multilingual content support"
       directory="profiles/default"
       provides="Products.GenericSetup.interfaces.EXTENSION"
-      for="Products.CMFPlone.interfaces.IPloneSiteRoot"/>
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      post_handler=".setuphandlers.init_pam"/>
 
   <genericsetup:registerProfile
       name="uninstall"

--- a/src/plone/app/multilingual/setuphandlers.py
+++ b/src/plone/app/multilingual/setuphandlers.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+from plone.api import portal
 from Products.CMFPlone.interfaces import INonInstallable
+from plone.app.multilingual.browser.setup import SetupMultilingualSite
 from zope.interface import implementer
 import pkg_resources
 
@@ -9,6 +11,7 @@ except pkg_resources.DistributionNotFound:
     HAS_PLONE_APP_CONTENTTYPES = False
 else:
     HAS_PLONE_APP_CONTENTTYPES = True
+
 
 
 @implementer(INonInstallable)
@@ -22,6 +25,12 @@ class HiddenProfiles(object):
         return [
             u'plone.app.multilingual:uninstall',
         ]
+
+
+def init_pam(tool):
+    """After installation run setup to create LRF and LIF."""
+    setup_tool = SetupMultilingualSite()
+    setup_tool.setupSite(portal.get())
 
 
 def step_default_various(context):

--- a/src/plone/app/multilingual/tests/test_setup.py
+++ b/src/plone/app/multilingual/tests/test_setup.py
@@ -1,39 +1,107 @@
 # -*- coding: utf-8 -*-
+import unittest2 as unittest
+from zope.interface import alsoProvides
+
 from Products.CMFCore.utils import getToolByName
+
 from plone.app.multilingual.browser.setup import SetupMultilingualSite
+from plone.app.multilingual.interfaces import IPloneAppMultilingualInstalled
 from plone.app.multilingual.browser.vocabularies import\
     AllContentLanguageVocabulary
-from plone.app.multilingual.testing import PAM_INTEGRATION_TESTING
-import unittest2 as unittest
-from plone.app.multilingual.interfaces import IPloneAppMultilingualInstalled
-from zope.interface import alsoProvides
+from plone.app.multilingual.testing import (PAM_INTEGRATION_TESTING,
+                                            PAM_INTEGRATION_PRESET_TESTING)
 
 
 class TestSetupMultilingualSite(unittest.TestCase):
+    """Testing multilingual site without predefined languages."""
 
     layer = PAM_INTEGRATION_TESTING
 
     def setUp(self):
+        """Setting up the test."""
         self.portal = self.layer['portal']
         self.request = self.layer['request']
+        self.language_tool = getToolByName(self.portal, 'portal_languages')
+        self.languages = self.language_tool.getSupportedLanguages()
         alsoProvides(self.layer['request'], IPloneAppMultilingualInstalled)
 
-    def test_add_all_supported_languages(self):
-        """There was a language which code is 'id' and it broke the root
-        language folder setup process
+    def test_single_language(self):
+        """Only one language is set."""
+        self.assertEqual(len(self.languages), 1)
+
+    def test_no_languagefolder_created(self):
+        """On a single language no folder creation is done."""
+        portal_objects = self.portal.objectIds()
+        for lang in self.languages:
+            self.assertNotIn(lang, portal_objects)
+
+    def test_all_supported_languages(self):
+        """There was a language which code is 'id'.
+
+        This broke the root language folder setup process.
+        To get rid of that the folder is 'id-id'.
         """
-        language_tool = getToolByName(self.portal, 'portal_languages')
-        for lang in AllContentLanguageVocabulary()(self.portal):
-            language_tool.addSupportedLanguage(lang.value)
+        all_langs = AllContentLanguageVocabulary()(self.portal)
+        for lang in all_langs:
+            self.language_tool.addSupportedLanguage(lang.value)
 
-        workflowTool = getToolByName(self.portal, "portal_workflow")
-        workflowTool.setDefaultChain('simple_publication_workflow')
+        workflow_tool = getToolByName(self.portal, "portal_workflow")
+        workflow_tool.setDefaultChain('simple_publication_workflow')
 
-        setupTool = SetupMultilingualSite()
-        setupTool.setupSite(self.portal)
+        setup_tool = SetupMultilingualSite()
+        setup_tool.setupSite(self.portal)
 
-        for lang in AllContentLanguageVocabulary()(self.portal):
-            if lang.value == 'id':
-                self.assertIn('id-id', self.portal.objectIds())
+        portal_objects = self.portal.objectIds()
+
+        for lang in all_langs.by_value.keys():
+            if lang == 'id':
+                self.assertIn('id-id', portal_objects)
             else:
-                self.assertIn(lang.value, self.portal.objectIds())
+                self.assertIn(lang, portal_objects)
+
+    def test_type_of_language_folders(self):
+        """The created objects have to be 'Language Root Folder'."""
+        all_langs = AllContentLanguageVocabulary()(self.portal)
+        for lang in all_langs:
+            self.language_tool.addSupportedLanguage(lang.value)
+
+        workflow_tool = getToolByName(self.portal, "portal_workflow")
+        workflow_tool.setDefaultChain('simple_publication_workflow')
+
+        setup_tool = SetupMultilingualSite()
+        setup_tool.setupSite(self.portal)
+
+        for lang in all_langs.by_value.keys():
+            if lang == 'id':
+                self.assertEqual(self.portal.get('id-id').portal_type, 'LRF')
+            else:
+                self.assertEqual(self.portal.get(lang).portal_type, 'LRF')
+
+
+class TestSetupMultilingualPresetSite(unittest.TestCase):
+    """Testing multilingual site with predefined languages."""
+
+    layer = PAM_INTEGRATION_PRESET_TESTING
+
+    def setUp(self):
+        """Setting up the test."""
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        self.language_tool = getToolByName(self.portal, 'portal_languages')
+        self.languages = self.language_tool.getSupportedLanguages()
+        alsoProvides(self.layer['request'], IPloneAppMultilingualInstalled)
+
+    def test_language_folders_created(self):
+        """Available languages are: 'en', 'ca', 'es'.
+
+        After setup has run there should be
+        new objects in the portal named after the languages.
+        """
+        portal_objects = self.portal.objectIds()
+        for lang in self.languages:
+            self.assertIn(lang, portal_objects)
+
+    def test_type_of_language_folders(self):
+        """The created objects have to be 'Language Root Folder'."""
+        for lang in self.languages:
+            self.assertEqual(self.portal.get(lang).portal_type, 'LRF')


### PR DESCRIPTION
Triggering SetupMultilingualSite after GS-Installation has run using post_hander.
To make previously set languages effect the folder-creation and replacement of language selector viewlet without hitting save on the controlpanel.


& fixed typo init_pma -> init_pam ...