### PR TITLE
Fixing issue with items cut & pasted into media folders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New:
 
 Fixes:
 
+- Correct event subscribers so that content cut from one LRF & pasted into the
+  Media folder is shown there when I switch to a second language.
+  [djowett]
+
 - *add item here*
 
 

--- a/src/plone/app/multilingual/configure.zcml
+++ b/src/plone/app/multilingual/configure.zcml
@@ -109,7 +109,7 @@
   <!-- Language independent folder content indexers -->
   <subscriber
       for="plone.dexterity.interfaces.IDexterityContent
-           zope.lifecycleevent.interfaces.IObjectAddedEvent"
+           zope.lifecycleevent.interfaces.IObjectMovedEvent"
       handler=".subscriber.reindex_language_independent"/>
 
   <subscriber

--- a/src/plone/app/multilingual/subscriber.py
+++ b/src/plone/app/multilingual/subscriber.py
@@ -39,6 +39,9 @@ def reindex_language_independent(ob, event):
     if not is_language_independent(ob):
         return
 
+    if IObjectRemovedEvent.providedBy(event):
+        return
+
     pc = getToolByName(ob, 'portal_catalog')
     parent = aq_parent(ob)
 

--- a/src/plone/app/multilingual/tests/test_subscribers.py
+++ b/src/plone/app/multilingual/tests/test_subscribers.py
@@ -2,6 +2,7 @@
 from plone.app.multilingual.interfaces import ILanguage
 from plone.app.multilingual.testing import PAM_FUNCTIONAL_TESTING
 from plone.dexterity.utils import createContentInContainer
+from Products.CMFCore.utils import getToolByName
 import unittest2 as unittest
 
 
@@ -59,3 +60,90 @@ class TestSubscribers(unittest.TestCase):
         self.portal['en'].manage_pasteObjects(id_)
         a_ca_copied = self.portal['en'][a_ca.id]
         self.assertEqual(ILanguage(a_ca_copied).get_language(), 'en')
+
+
+    def test_moved_to_media_folder(self):
+        """When an object is moved from within one Language Root Folder into
+        the Language Independent Folder (named 'Media') it becomes language 
+        independent, and it should be visible from the media folder accessed
+        from within other Language Root Folders
+        """
+        a_ca = createContentInContainer(
+            self.portal['ca'], 'Document', title=u"Test document")
+
+        # Test a paste into a subfolder to be ultra cautious
+        ca_media_subfolder = createContentInContainer(
+            self.portal['ca']['media'], 'Folder', title=u"A Folder")
+
+        subfolder_name = ca_media_subfolder.id
+
+        id_ = self.portal['ca'].manage_cutObjects(a_ca.id)
+        ca_media_subfolder.manage_pasteObjects(id_)
+
+        # Get both media folders afresh
+        ca_media_subfolder = self.portal['ca']['media'][subfolder_name]
+        en_media_subfolder = self.portal['en']['media'][subfolder_name]
+        
+        # Check it is in both folder listings
+        self.assertTrue(a_ca.id in ca_media_subfolder)
+        self.assertTrue(a_ca.id in en_media_subfolder)
+
+        # Check it is language independent
+        copy_in_en = en_media_subfolder[a_ca.id]
+        self.assertEqual(ILanguage(copy_in_en).get_language(), '')
+        copy_in_ca = ca_media_subfolder[a_ca.id]
+        self.assertEqual(ILanguage(copy_in_ca).get_language(), '')
+
+        # Check it is returned in catalog search
+        catalog = getToolByName(self.portal, 'portal_catalog')
+
+        ca_subfolder_path = '/'.join(ca_media_subfolder.getPhysicalPath())
+        ca_folder_contents = [r.id for r in catalog(path=ca_subfolder_path)]
+        self.assertTrue(a_ca.id in ca_folder_contents)
+
+        en_subfolder_path = '/'.join(en_media_subfolder.getPhysicalPath())
+        en_folder_contents = [r.id for r in catalog(path=en_subfolder_path)]
+        self.assertTrue(a_ca.id in en_folder_contents)
+
+
+    def test_copied_to_media_folder(self):
+        """When an object is copied from within one Language Root Folder into
+        the Language Independent Folder (named 'Media') it becomes language 
+        independent, and it should be visible from the media folder accessed
+        from within other Language Root Folders
+        """
+        a_ca = createContentInContainer(
+            self.portal['ca'], 'Document', title=u"Test document")
+
+        # Test a paste into a subfolder to be ultra cautious
+        ca_media_subfolder = createContentInContainer(
+            self.portal['ca']['media'], 'Folder', title=u"A Folder")
+
+        subfolder_name = ca_media_subfolder.id
+        id_ = self.portal['ca'].manage_copyObjects(a_ca.id)
+        ca_media_subfolder.manage_pasteObjects(id_)
+
+        # Get both media folders afresh
+        ca_media_subfolder = self.portal['ca']['media'][subfolder_name]
+        en_media_subfolder = self.portal['en']['media'][subfolder_name]
+        
+        # Check it is in both folder listings
+        self.assertTrue(a_ca.id in ca_media_subfolder)
+        self.assertTrue(a_ca.id in en_media_subfolder)
+
+        # Check it is language independent
+        copy_in_en = en_media_subfolder[a_ca.id]
+        self.assertEqual(ILanguage(copy_in_en).get_language(), '')
+        copy_in_ca = ca_media_subfolder[a_ca.id]
+        self.assertEqual(ILanguage(copy_in_ca).get_language(), '')
+
+        # Check it is returned in catalog search
+        catalog = getToolByName(self.portal, 'portal_catalog')
+
+        ca_subfolder_path = '/'.join(ca_media_subfolder.getPhysicalPath())
+        ca_folder_contents = [r.id for r in catalog(path=ca_subfolder_path)]
+        self.assertTrue(a_ca.id in ca_folder_contents)
+
+        en_subfolder_path = '/'.join(en_media_subfolder.getPhysicalPath())
+        en_folder_contents = [r.id for r in catalog(path=en_subfolder_path)]
+        self.assertTrue(a_ca.id in en_folder_contents)

--- a/src/plone/app/multilingual/tests/test_subscribers.py
+++ b/src/plone/app/multilingual/tests/test_subscribers.py
@@ -35,6 +35,10 @@ class TestSubscribers(unittest.TestCase):
         self.assertEqual(ILanguage(a_ca).get_language(), '')
 
     def test_moved_event(self):
+        """When an object is moved from within one Language Root Folder into
+        a different Language Root Folder it changes its language to that of the
+        folder it is copied into
+        """
         a_ca = createContentInContainer(
             self.portal['ca'], 'Document', title=u"Test document")
 
@@ -44,6 +48,10 @@ class TestSubscribers(unittest.TestCase):
         self.assertEqual(ILanguage(a_ca_copied).get_language(), 'en')
 
     def test_copied_event(self):
+        """When an object is copied from within one Language Root Folder into
+        a different Language Root Folder it changes its language to that of the
+        folder it is copied into
+        """
         a_ca = createContentInContainer(
             self.portal['ca'], 'Document', title=u"Test document")
 


### PR DESCRIPTION
these tests prove that they are not visible in other media folders

Perhaps we are [registering the handler against the wrong events](https://github.com/plone/plone.app.multilingual/blob/2.x/src/plone/app/multilingual/configure.zcml#L109-L123)?