### PR TITLE
Fixed unstable robot test by waiting until expected text is on page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed unstable robot test by waiting until the expected text is on the page.  [maurits]
 
 
 4.0.1 (2016-06-07)

--- a/src/plone/app/multilingual/tests/robot/test_translate_content.robot
+++ b/src/plone/app/multilingual/tests/robot/test_translate_content.robot
@@ -58,6 +58,7 @@ I translate the document into Catalan
   Click Link  Dates  # workaround for of TinyMCE editor field problem
   Click Button  Guardar
   Wait until page contains  Element creat
+  Wait until page contains  A Catalan Document
 
 I switch to Catalan
   Click Link  xpath=//a[@title='Català']


### PR DESCRIPTION
I saw this go wrong on Jenkins pull requests, for example:
http://jenkins.plone.org/job/pull-request-5.0/1215/
