### PR TITLE
RelatedItems widget changes for Mockp 2.3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Change RelatedItemsFieldWidget configuration from ``@@add_translations`` view to support Mockup 2.4.0, so that the widget is able to navigate beyond the INavigationRoot boundary and to access other translation trees.
+  This change keeps compatibility with older versions of Mockup or Mockup-less setups.
+  [thet]
 
 
 4.0.3 (2016-08-15)


### PR DESCRIPTION
Adapt RelatedItemsFieldWidget from @@add_translations view to changes in mockup 2.3.0.

Part of: https://github.com/plone/mockup/pull/696