### PR TITLE
only require archetypes.multilingual if the archetypes extra is requested

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,8 @@ Changelog
 
 Breaking changes:
 
-- Support for Archetypes content is only installed
-  if you install `archetypes.multilingual`.
+- Support for Archetypes content is only installed if you install `archetypes.multilingual.
+  For Archetypes support, there is a new ``archetypes`` ``extras_require``, which you can depend upon.
   [davisagli]
 
 New features:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Changelog
 
 Breaking changes:
 
-- *add item here*
+- Support for Archetypes content is only installed
+  if you install `archetypes.multilingual`.
+  [davisagli]
 
 New features:
 

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ PAM is composed of two packages, one is mandatory:
 
     * plone.app.multilingual (core, UI, enables Dexterity support via a behavior)
 
-and one optional (at least one should be installed):
+and one optional:
 
     * archetypes.multilingual (enables Archetypes support)
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     install_requires=[
         'Products.CMFPlone>=5.0b1',
         'Products.GenericSetup>=1.8.2',
-        'archetypes.multilingual',
         'plone.app.registry',
         'plone.app.z3cform',
         'plone.behavior',
@@ -47,6 +46,9 @@ setup(
         'zope.publisher',
     ],
     extras_require={
+        'archetypes': [
+            'archetypes.multilingual',
+        ],
         'test': [
             'plone.app.testing[robot]>=4.2.2',
             'plone.app.robotframework',


### PR DESCRIPTION
This makes it possible to install Products.CMFPlone without getting Archetypes.

This should be tested and merged after https://github.com/plone/Plone/pull/5 and https://github.com/plone/Plone/pull/6 which make sure that archetypes.multilingual will still be installed by default when you install `Plone` (until we are ready to end support for Archetypes).