### PR TITLE
avoid breaking Plone 5.1 when Archetypes is gone

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -135,7 +135,7 @@ Bug fixes:
 Breaking changes:
 
 - Support for Archetypes content is only installed if you install `archetypes.multilingual.
-  For Archetypes support, there is a new ``archetypes`` ``extras_require``, which you can depend upon.
+  For Archetypes support, there is a new ``archetypes`` ``extras_require``, which you can depend upon. 
   [davisagli]
 
 New features:

--- a/src/plone/app/multilingual/browser/helper_views.py
+++ b/src/plone/app/multilingual/browser/helper_views.py
@@ -27,13 +27,14 @@ from zope.publisher.interfaces import IPublishTraverse
 from zope.publisher.interfaces import NotFound
 
 try:
+    # Archetypes installed
     from Products.ATContentTypes.interfaces.factory import IFactoryTool
 except ImportError:
     try:
+        # Plone 5.0 without Archetypes
         from Products.CMFPlone.interfaces.factory import IFactoryTool
     except ImportError:
-        # gone in Plone 5.1 w/o ATCT
-
+        # Plone 5.1 without Archetypes
         class IFactoryTool(Interface):
             pass
 


### PR DESCRIPTION
In Plone 5.1, IFactoryTool is no longer defined in CMFPlone, so we need to handle when it is missing.
