### PR TITLE
Made robot tests more robust, I hope.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,14 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Made robot tests more robust, I hope.
+  Before using 'Wait until element is visible',
+  first call   'Wait until page contains element'.
+  The first one only works reliably when the element was already on the page initially.
+  If the element was created dynamically, you need to use the 'page contains' call first,
+  otherwise you sometimes get an error:
+  'Element not found in the cache - perhaps the page has changed since it was looked up.'
+  [maurits]
 
 
 4.0.4 (2016-09-16)

--- a/src/plone/app/multilingual/tests/robot/test_add_translation.robot
+++ b/src/plone/app/multilingual/tests/robot/test_add_translation.robot
@@ -49,6 +49,7 @@ I view the Catalan document
 
 I link the document in English as a translation
   Click Element  css=#plone-contentmenu-multilingual a
+  Wait until page contains element  css=#_modify_translations
   Wait until element is visible  css=#_modify_translations
 
   Click Element  css=#_modify_translations
@@ -57,8 +58,10 @@ I link the document in English as a translation
   ...  css=#translations-overview .connectTranslationAction
 
   Click Element  css=#translations-overview .connectTranslationAction
+  Wait until page contains element  css=.select2-choices
   Wait until element is visible  css=.select2-choices
   Click Element  css=#formfield-form-widgets-content .select2-choices
+  Wait until page contains element  xpath=(//span[contains(., 'An English Document')])
   Wait until element is visible  xpath=(//span[contains(., 'An English Document')])
   Click Element  xpath=(//span[contains(., 'An English Document')])
   Wait until page contains  An English Document

--- a/src/plone/app/multilingual/tests/robot/test_add_translation.robot
+++ b/src/plone/app/multilingual/tests/robot/test_add_translation.robot
@@ -68,6 +68,7 @@ I link the document in English as a translation
 
   Click Element  xpath=(//*[contains(@class, 'plone-modal-footer')]//input[@id='form-buttons-connect_translation'])
   Wait until page contains element  xpath=(//h3[@class="translationTitle"])
+  Sleep  5
   Wait until element is visible  xpath=(//h3[@class="translationTitle"])
   Focus  xpath=(//*[@class="odd"]//a[contains(@href,"a-catalan-document")])
   Click Element  xpath=(//*[@class="odd"]//a[contains(@href,"a-catalan-document")])


### PR DESCRIPTION
Before using 'Wait until element is visible',
first call   'Wait until page contains element'.

The first one only works reliably when the element was already on the page initially.
If the element was created dynamically, you need to use the 'page contains' call first,
otherwise you sometimes get an error:

'Element not found in the cache - perhaps the page has changed since it was looked up.'

Note 1: I am not sure if the 'page contains' is necessary in all these cases, but I don't see in Jenkins where it exactly goes wrong.

Note 2: if the pull request tests pass to 5.0 and 5.1, we should probably run them a second time.  It fails off and on.