### PR TITLE
Add '@@tg' view for accessing translation group of the object TTW

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Add a new view ``@@tg`` for translatable content. It will return the
+  current translation group of the content, matching the bahavior of ``@@uuid``
+  of ``plone.app.uuid`` returning UUID of the content.  [datakurre]
 
 Bug fixes:
 

--- a/src/plone/app/multilingual/browser/configure.zcml
+++ b/src/plone/app/multilingual/browser/configure.zcml
@@ -142,6 +142,14 @@
       permission="zope.Public"
       layer="..interfaces.IPloneAppMultilingualInstalled"/>
 
+  <!-- Translation Group -->
+  <browser:page
+      name="tg"
+      for="plone.app.multilingual.interfaces.ITranslatable"
+      class=".helper_views.TGView"
+      permission="zope.Public"
+      layer="..interfaces.IPloneAppMultilingualInstalled"/>
+
   <!-- Selector -->
   <browser:page
       name="multilingual-selector"

--- a/src/plone/app/multilingual/browser/helper_views.py
+++ b/src/plone/app/multilingual/browser/helper_views.py
@@ -9,6 +9,7 @@ from plone.i18n.interfaces import INegotiateLanguage
 from borg.localrole.interfaces import IFactoryTempFolder
 from plone.app.layout.navigation.interfaces import INavigationRoot
 from plone.app.multilingual.interfaces import IMultiLanguageExtraOptionsSchema
+from plone.app.multilingual.interfaces import ITG
 from plone.app.multilingual.browser.selector import NOT_TRANSLATED_YET_TEMPLATE
 from plone.app.multilingual.browser.selector import addQuery
 from plone.app.multilingual.interfaces import ILanguageRootFolder
@@ -278,3 +279,11 @@ class not_translated_yet(BrowserView):
         if lang_info is None:
             return None
         return lang_info.get('native', None) or lang_info.get('name')
+
+
+class TGView(BrowserView):
+    """A simple browser view that renders the TG of its context
+    """
+
+    def __call__(self):
+        return str(ITG(self.context, u""))

--- a/src/plone/app/multilingual/tests/test_api.py
+++ b/src/plone/app/multilingual/tests/test_api.py
@@ -3,6 +3,7 @@ from OFS.event import ObjectWillBeRemovedEvent
 from Products.CMFCore.utils import getToolByName
 from plone.app.multilingual import api
 from Products.CMFPlone.interfaces import ILanguage
+from plone.app.multilingual.interfaces import ATTRIBUTE_NAME
 from plone.app.multilingual.interfaces import ITranslationIdChooser
 from plone.app.multilingual.interfaces import ITranslationLocator
 from plone.app.multilingual.interfaces import ITranslationManager
@@ -293,3 +294,13 @@ class TestLanguageRootFolderAPI(unittest.TestCase):
 
         child_locator = ITranslationLocator(subfolder_ca)
         self.assertEqual(child_locator('es'), folder_es)
+
+    def test_tg_view(self):
+        a_ca = createContentInContainer(
+            self.portal['ca'],
+            'Document',
+            title=u"Test document"
+        )
+        tg = getattr(a_ca, ATTRIBUTE_NAME)
+        self.assertTrue(bool(tg))
+        self.assertEqual(a_ca.restrictedTraverse('@@tg')(), tg)


### PR DESCRIPTION
Translation group is used in universal link and translation locator URLs, but is not easily available TTW. Because its comparable to IUUID with ``@@uuid``, I propose also exposing it in a similar way (``@@tg``).

(Personally, I have a theming related use case for this.)