### PR TITLE
Refactor translation menu

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-5.0.9 (unreleased)
+5.1.0 (unreleased)
 ------------------
 
 Breaking changes:
@@ -16,6 +16,22 @@ New features:
 - Rename ``media`` folder to a more generic name ``assets`` by default and
   add i18nize it to be localization aware
   [agitator, datakurre]
+- When viewing a folder with a default page, the translation menu shows all
+  options for both the folder and then the default page in the
+  same order and with the same titles. The option to edit the current page in
+  babel view have been merged with the options to edit the other translations
+  to make the menu more consistent
+  [datakurre]
+
+- Translation menu show the title of the language independent folder on
+  the language independent folder link in translation menu as
+  "Open ${title} folder"
+  [datakurre]
+
+- Translation menu no longer includes "Set content language"-menuitem, which
+  was redundant (but less transparent in its behavior) to just cutting and
+  pasting a content under the desired language folder
+  [datakurre]
 
 Bug fixes:
 

--- a/src/plone/app/multilingual/browser/stylesheet/multilingual.css
+++ b/src/plone/app/multilingual/browser/stylesheet/multilingual.css
@@ -109,4 +109,12 @@ a.contentmenuflags img {
 #translations-overview .actionLabel {
     display: none;
 }
-
+#edit-zone nav > ul ul li.plonetoolbar-multilingual.actionSeparator {
+    margin: 0;
+    padding: 5px 0 0;
+    border-top: 1px solid rgba(255,255,255,0.17);
+}
+#edit-zone nav>ul ul li.plonetoolbar-multilingual.actionSeparator>span {
+    font-weight: 400;
+    color: #ccc;
+}

--- a/src/plone/app/multilingual/locales/ca/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/ca/LC_MESSAGES/plone.app.multilingual.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.2b3\n"
-"POT-Creation-Date: 2017-07-10 06:24+0000\n"
+"POT-Creation-Date: 2017-07-13 21:35+0000\n"
 "PO-Revision-Date: 2012-03-23 16:45 +0000\n"
 "Last-Translator: ramon.nb@gmail.com>\n"
 "Language-Team: plone-cat <plone-cat@plone.org>\n"
@@ -168,13 +168,8 @@ msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:122
+#: ../browser/menu.py:161
 msgid "create_translation"
-msgstr ""
-
-#. Default: "Create ${lang_name} folder"
-#: ../browser/menu.py:118
-msgid "create_translation_folder"
 msgstr ""
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
@@ -182,13 +177,8 @@ msgstr ""
 msgid "description_after_migration_cleanup"
 msgstr ""
 
-#. Default: "Edit with the babel_edit"
-#: ../browser/menu.py:70
-msgid "description_babel_edit"
-msgstr ""
-
-#. Default: "Babel edit ${lang_name}"
-#: ../browser/menu.py:139
+#. Default: "Edit {lang_name} with the two-column translation view"
+#: ../browser/menu.py:117
 msgid "description_babeledit_menu"
 msgstr ""
 
@@ -213,7 +203,7 @@ msgid "description_google_translation_key"
 msgstr ""
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:193
+#: ../browser/menu.py:466
 msgid "description_language_folder"
 msgstr ""
 
@@ -233,7 +223,7 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:171
+#: ../browser/menu.py:219
 msgid "description_modify_translations"
 msgstr ""
 
@@ -257,13 +247,13 @@ msgstr ""
 msgid "description_selector_lookup_translations_policy"
 msgstr ""
 
-#. Default: "Set or change the current content language"
-#: ../browser/menu.py:255
+#. Default: "Move the translation under another language folder"
+#: ../browser/menu.py:140
 msgid "description_set_language"
 msgstr ""
 
-#. Default: "Show the shared Language Independent Folder"
-#: ../browser/menu.py:236
+#. Default: "Open the language independent assets folder"
+#: ../browser/menu.py:445
 msgid "description_shared_folder"
 msgstr ""
 
@@ -273,7 +263,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:102
+#: ../browser/menu.py:166
 msgid "description_translate_into"
 msgstr ""
 
@@ -282,8 +272,8 @@ msgstr ""
 msgid "description_translation_map"
 msgstr ""
 
-#. Default: "Universal Language content link"
-#: ../browser/menu.py:215
+#. Default: "Universal link to the content in user's preferred language"
+#: ../browser/menu.py:239
 msgid "description_universal_link"
 msgstr ""
 
@@ -293,13 +283,8 @@ msgid "description_update_language"
 msgstr ""
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:159
+#: ../browser/menu.py:112
 msgid "edit_translation"
-msgstr ""
-
-#. Default: "Edit ${lang_name} folder"
-#: ../browser/menu.py:155
-msgid "edit_translation_folder"
 msgstr ""
 
 #. Default: "Folder's id is not a valid language code"
@@ -445,7 +430,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:276
+#: ../browser/menu.py:491
 msgid "label_translate_menu"
 msgstr "Tradueix"
 
@@ -461,7 +446,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:189
+#: ../browser/menu.py:462
 msgid "language_folder"
 msgstr ""
 
@@ -520,8 +505,8 @@ msgstr ""
 msgid "relation_migration_with_not_needed"
 msgstr ""
 
-#. Default: "Go to Assets folder"
-#: ../browser/menu.py:232
+#. Default: "Open ${title} folder"
+#: ../browser/menu.py:440
 #, fuzzy
 msgid "shared_folder"
 msgstr "Anar a Carpeta compartida"
@@ -531,28 +516,34 @@ msgstr "Anar a Carpeta compartida"
 msgid "title_available_languages"
 msgstr ""
 
-#. Default: "Edit with babel view"
-#: ../browser/menu.py:66
-msgid "title_babel_edit"
-msgstr "Editar amb vista babel"
-
 #. Default: "Language"
 #: ../browser/interfaces.py:54
 msgid "title_language"
 msgstr "Llenguatge"
 
-#. Default: "Modify translations..."
-#: ../browser/menu.py:167
+#. Default: "Manage translations"
+#: ../browser/menu.py:215
 msgid "title_modify_translations"
 msgstr ""
 
-#. Default: "Set content language"
-#: ../browser/menu.py:251
+#. Default: "Change content language"
+#: ../browser/menu.py:136
+#, fuzzy
 msgid "title_set_language"
 msgstr "Establir Idioma del contingut"
 
+#. Default: "Folder translation"
+#: ../browser/menu.py:258
+msgid "title_translate_current_folder"
+msgstr ""
+
+#. Default: "Item translation"
+#: ../browser/menu.py:422
+msgid "title_translate_current_item"
+msgstr ""
+
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:277
+#: ../browser/menu.py:492
 msgid "title_translate_menu"
 msgstr "Administra les traduccions del teu contingut"
 
@@ -566,8 +557,9 @@ msgstr ""
 msgid "translation_to"
 msgstr ""
 
-#. Default: "Universal Link"
-#: ../browser/menu.py:211
+#. Default: "Universal link"
+#: ../browser/menu.py:235
+#, fuzzy
 msgid "universal_link"
 msgstr "Link universal"
 

--- a/src/plone/app/multilingual/locales/de/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/de/LC_MESSAGES/plone.app.multilingual.po
@@ -182,15 +182,10 @@ msgstr "Erstelle Übersetzung für Ordner"
 msgid "description_after_migration_cleanup"
 msgstr ""
 
-#. Default: "Edit with the babel_edit"
-#: ../browser/menu.py:70
-msgid "description_babel_edit"
-msgstr ""
-
-#. Default: "Babel edit ${lang_name}"
-#: ../browser/menu.py:139
+#. Default: "Edit {lang_name} with the two-column translation view"
+#: ../browser/menu.py:117
 msgid "description_babeledit_menu"
-msgstr "Editieren mit Babel-Ansicht"
+msgstr "Editieren"
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
 #: ../interfaces.py:240
@@ -520,11 +515,10 @@ msgstr ""
 msgid "relation_migration_with_not_needed"
 msgstr ""
 
-#. Default: "Go to Assets folder"
-#: ../browser/menu.py:232
-#, fuzzy
+#. Default: "Open ${title} folder"
+#: ../browser/menu.py:440
 msgid "shared_folder"
-msgstr "Gehe zu 'shared'-Ordner"
+msgstr "${title} Ordner öffnen"
 
 #. Default: "Available languages"
 #: ../browser/interfaces.py:62
@@ -544,7 +538,7 @@ msgstr "Sprache"
 #. Default: "Modify translations..."
 #: ../browser/menu.py:167
 msgid "title_modify_translations"
-msgstr ""
+msgstr "Übersetzungen verwalten"
 
 #. Default: "Set content language"
 #: ../browser/menu.py:251

--- a/src/plone/app/multilingual/locales/de/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/de/LC_MESSAGES/plone.app.multilingual.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone.app.multilingual\n"
-"POT-Creation-Date: 2017-07-10 06:24+0000\n"
+"POT-Creation-Date: 2017-07-13 21:35+0000\n"
 "PO-Revision-Date: 2013-06-05 11:55+0100\n"
 "Last-Translator: CMS HU Berlin <plone@cms.hu-berlin.de>\n"
 "Language-Team: CMS HU Berlin <plone@cms.hu-berlin.de>\n"
@@ -168,14 +168,9 @@ msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:122
+#: ../browser/menu.py:161
 msgid "create_translation"
 msgstr "${lang_name}"
-
-#. Default: "Create ${lang_name} folder"
-#: ../browser/menu.py:118
-msgid "create_translation_folder"
-msgstr "Erstelle Übersetzung für Ordner"
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
 #: ../browser/templates/migration.pt:225
@@ -208,7 +203,7 @@ msgid "description_google_translation_key"
 msgstr ""
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:193
+#: ../browser/menu.py:466
 msgid "description_language_folder"
 msgstr ""
 
@@ -228,7 +223,7 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:171
+#: ../browser/menu.py:219
 msgid "description_modify_translations"
 msgstr ""
 
@@ -252,13 +247,14 @@ msgstr ""
 msgid "description_selector_lookup_translations_policy"
 msgstr ""
 
-#. Default: "Set or change the current content language"
-#: ../browser/menu.py:255
+#. Default: "Move the translation under another language folder"
+#: ../browser/menu.py:140
+#, fuzzy
 msgid "description_set_language"
 msgstr "Sprache setzen oder ändern."
 
-#. Default: "Show the shared Language Independent Folder"
-#: ../browser/menu.py:236
+#. Default: "Open the language independent assets folder"
+#: ../browser/menu.py:445
 msgid "description_shared_folder"
 msgstr ""
 
@@ -268,7 +264,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:102
+#: ../browser/menu.py:166
 msgid "description_translate_into"
 msgstr "Übersetzen in ${lang_name}"
 
@@ -277,8 +273,8 @@ msgstr "Übersetzen in ${lang_name}"
 msgid "description_translation_map"
 msgstr ""
 
-#. Default: "Universal Language content link"
-#: ../browser/menu.py:215
+#. Default: "Universal link to the content in user's preferred language"
+#: ../browser/menu.py:239
 msgid "description_universal_link"
 msgstr ""
 
@@ -288,14 +284,9 @@ msgid "description_update_language"
 msgstr "Sprachen, in die der Inhalt noch nicht übersetzt wurde."
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:159
+#: ../browser/menu.py:112
 msgid "edit_translation"
 msgstr "${lang_name} editieren"
-
-#. Default: "Edit ${lang_name} folder"
-#: ../browser/menu.py:155
-msgid "edit_translation_folder"
-msgstr "Editiere Übersetzung für Ordner"
 
 #. Default: "Folder's id is not a valid language code"
 #: ../browser/migrator.py:308
@@ -440,7 +431,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:276
+#: ../browser/menu.py:491
 msgid "label_translate_menu"
 msgstr "Übersetzen..."
 
@@ -456,7 +447,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:189
+#: ../browser/menu.py:462
 msgid "language_folder"
 msgstr ""
 
@@ -525,28 +516,35 @@ msgstr "${title} Ordner öffnen"
 msgid "title_available_languages"
 msgstr "Verfügbare Sprachen"
 
-#. Default: "Edit with babel view"
-#: ../browser/menu.py:66
-msgid "title_babel_edit"
-msgstr "Editieren in Babel-View"
-
 #. Default: "Language"
 #: ../browser/interfaces.py:54
 msgid "title_language"
 msgstr "Sprache"
 
-#. Default: "Modify translations..."
-#: ../browser/menu.py:167
+#. Default: "Manage translations"
+#: ../browser/menu.py:215
+#, fuzzy
 msgid "title_modify_translations"
 msgstr "Übersetzungen verwalten"
 
-#. Default: "Set content language"
-#: ../browser/menu.py:251
+#. Default: "Change content language"
+#: ../browser/menu.py:136
+#, fuzzy
 msgid "title_set_language"
 msgstr "Sprache setzen"
 
+#. Default: "Folder translation"
+#: ../browser/menu.py:258
+msgid "title_translate_current_folder"
+msgstr ""
+
+#. Default: "Item translation"
+#: ../browser/menu.py:422
+msgid "title_translate_current_item"
+msgstr ""
+
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:277
+#: ../browser/menu.py:492
 msgid "title_translate_menu"
 msgstr "Übersetzungen verwalten"
 
@@ -560,8 +558,8 @@ msgstr ""
 msgid "translation_to"
 msgstr "Übersetzen in ${language}"
 
-#. Default: "Universal Link"
-#: ../browser/menu.py:211
+#. Default: "Universal link"
+#: ../browser/menu.py:235
 msgid "universal_link"
 msgstr ""
 

--- a/src/plone/app/multilingual/locales/es/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/es/LC_MESSAGES/plone.app.multilingual.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.2b3\n"
-"POT-Creation-Date: 2017-07-10 06:24+0000\n"
+"POT-Creation-Date: 2017-07-13 21:35+0000\n"
 "PO-Revision-Date: 2012-03-23 16:45 +0000\n"
 "Last-Translator: ramon.nb@gmail.com>\n"
 "Language-Team: plone-cat <plone-cat@plone.org>\n"
@@ -168,27 +168,17 @@ msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:122
+#: ../browser/menu.py:161
 msgid "create_translation"
 msgstr "Crear ${lang_name}"
-
-#. Default: "Create ${lang_name} folder"
-#: ../browser/menu.py:118
-msgid "create_translation_folder"
-msgstr ""
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
 #: ../browser/templates/migration.pt:225
 msgid "description_after_migration_cleanup"
 msgstr ""
 
-#. Default: "Edit with the babel_edit"
-#: ../browser/menu.py:70
-msgid "description_babel_edit"
-msgstr ""
-
-#. Default: "Babel edit ${lang_name}"
-#: ../browser/menu.py:139
+#. Default: "Edit {lang_name} with the two-column translation view"
+#: ../browser/menu.py:117
 msgid "description_babeledit_menu"
 msgstr ""
 
@@ -213,7 +203,7 @@ msgid "description_google_translation_key"
 msgstr ""
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:193
+#: ../browser/menu.py:466
 msgid "description_language_folder"
 msgstr ""
 
@@ -233,7 +223,7 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:171
+#: ../browser/menu.py:219
 msgid "description_modify_translations"
 msgstr ""
 
@@ -257,13 +247,13 @@ msgstr ""
 msgid "description_selector_lookup_translations_policy"
 msgstr ""
 
-#. Default: "Set or change the current content language"
-#: ../browser/menu.py:255
+#. Default: "Move the translation under another language folder"
+#: ../browser/menu.py:140
 msgid "description_set_language"
 msgstr ""
 
-#. Default: "Show the shared Language Independent Folder"
-#: ../browser/menu.py:236
+#. Default: "Open the language independent assets folder"
+#: ../browser/menu.py:445
 msgid "description_shared_folder"
 msgstr ""
 
@@ -273,7 +263,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:102
+#: ../browser/menu.py:166
 msgid "description_translate_into"
 msgstr ""
 
@@ -282,8 +272,8 @@ msgstr ""
 msgid "description_translation_map"
 msgstr ""
 
-#. Default: "Universal Language content link"
-#: ../browser/menu.py:215
+#. Default: "Universal link to the content in user's preferred language"
+#: ../browser/menu.py:239
 msgid "description_universal_link"
 msgstr ""
 
@@ -293,13 +283,8 @@ msgid "description_update_language"
 msgstr ""
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:159
+#: ../browser/menu.py:112
 msgid "edit_translation"
-msgstr ""
-
-#. Default: "Edit ${lang_name} folder"
-#: ../browser/menu.py:155
-msgid "edit_translation_folder"
 msgstr ""
 
 #. Default: "Folder's id is not a valid language code"
@@ -445,7 +430,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:276
+#: ../browser/menu.py:491
 msgid "label_translate_menu"
 msgstr "Traducciones"
 
@@ -461,7 +446,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:189
+#: ../browser/menu.py:462
 msgid "language_folder"
 msgstr ""
 
@@ -520,8 +505,8 @@ msgstr ""
 msgid "relation_migration_with_not_needed"
 msgstr ""
 
-#. Default: "Go to Assets folder"
-#: ../browser/menu.py:232
+#. Default: "Open ${title} folder"
+#: ../browser/menu.py:440
 #, fuzzy
 msgid "shared_folder"
 msgstr "Ir a carpeta compartida"
@@ -531,28 +516,34 @@ msgstr "Ir a carpeta compartida"
 msgid "title_available_languages"
 msgstr ""
 
-#. Default: "Edit with babel view"
-#: ../browser/menu.py:66
-msgid "title_babel_edit"
-msgstr "Editar con vista babel"
-
 #. Default: "Language"
 #: ../browser/interfaces.py:54
 msgid "title_language"
 msgstr ""
 
-#. Default: "Modify translations..."
-#: ../browser/menu.py:167
+#. Default: "Manage translations"
+#: ../browser/menu.py:215
 msgid "title_modify_translations"
 msgstr ""
 
-#. Default: "Set content language"
-#: ../browser/menu.py:251
+#. Default: "Change content language"
+#: ../browser/menu.py:136
+#, fuzzy
 msgid "title_set_language"
 msgstr "Establecer idioma del contenido"
 
+#. Default: "Folder translation"
+#: ../browser/menu.py:258
+msgid "title_translate_current_folder"
+msgstr ""
+
+#. Default: "Item translation"
+#: ../browser/menu.py:422
+msgid "title_translate_current_item"
+msgstr ""
+
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:277
+#: ../browser/menu.py:492
 msgid "title_translate_menu"
 msgstr ""
 
@@ -566,8 +557,9 @@ msgstr ""
 msgid "translation_to"
 msgstr ""
 
-#. Default: "Universal Link"
-#: ../browser/menu.py:211
+#. Default: "Universal link"
+#: ../browser/menu.py:235
+#, fuzzy
 msgid "universal_link"
 msgstr "Link universal"
 

--- a/src/plone/app/multilingual/locales/eu/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/eu/LC_MESSAGES/plone.app.multilingual.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone.app.multilingual\n"
-"POT-Creation-Date: 2017-07-10 06:24+0000\n"
+"POT-Creation-Date: 2017-07-13 21:35+0000\n"
 "PO-Revision-Date: 2017-07-10 08:29+0200\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: eu <eu@li.org>\n"
@@ -31,7 +31,8 @@ msgstr "Utzi"
 msgid "Changes canceled."
 msgstr "Aldaketak bertan behera utzi dira"
 
-#: ../browser/templates/cleanup.pt:79 ../browser/templates/migration.pt:250
+#: ../browser/templates/cleanup.pt:79
+#: ../browser/templates/migration.pt:250
 msgid "Cleanup"
 msgstr "Garbitu"
 
@@ -72,7 +73,8 @@ msgstr "Multilingual"
 msgid "Multilingual Settings"
 msgstr "Eleaniztasun-aukerak"
 
-#: ../configure.zcml:151 ../dx/configure.zcml:36
+#: ../configure.zcml:151
+#: ../dx/configure.zcml:36
 msgid "Multilingual Support"
 msgstr "Eleaniztasun-aukerak"
 
@@ -170,27 +172,18 @@ msgid "create-object-without-translation"
 msgstr "Elementu hau itzulpena izan gabe sortzeko <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">sakatu hemen</a>"
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:122
+#: ../browser/menu.py:161
 msgid "create_translation"
 msgstr "${lang_name} itzulpena sortu"
-
-#. Default: "Create ${lang_name} folder"
-#: ../browser/menu.py:118
-msgid "create_translation_folder"
-msgstr "${lang_name} karpeta sortu"
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
 #: ../browser/templates/migration.pt:225
 msgid "description_after_migration_cleanup"
 msgstr "Pausu honek ITranslatabe interfazearen dependentzia batzuk kkonponduko ditu. LinguaPlone guztiz desinstalatuta dagoenen bakarrik exekutatu behar da."
 
-#. Default: "Edit with the babel_edit"
-#: ../browser/menu.py:70
-msgid "description_babel_edit"
-msgstr "babel_edit erabiliz editatu"
-
-#. Default: "Babel edit ${lang_name}"
-#: ../browser/menu.py:139
+#. Default: "Edit {lang_name} with the two-column translation view"
+#: ../browser/menu.py:117
+#, fuzzy
 msgid "description_babeledit_menu"
 msgstr "Babel edizioa ${lang_name}"
 
@@ -215,7 +208,7 @@ msgid "description_google_translation_key"
 msgstr "Google-ren itzulpen zerbitzua erabiltzeko API gakoa (ordainpeko zerbitzua)"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:193
+#: ../browser/menu.py:466
 msgid "description_language_folder"
 msgstr "Erabiltzailearen nabigatzailearen hobespenek dioten hizkuntzara joan"
 
@@ -235,7 +228,7 @@ msgid "description_migration_results"
 msgstr "Hemen migrazioaren emaitzak ikusiko dituzu"
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:171
+#: ../browser/menu.py:219
 msgid "description_modify_translations"
 msgstr "Itzulpenak gehitu edo ezabatu"
 
@@ -259,13 +252,15 @@ msgstr "Pausu honek, elementuak beren hizkuntzaren arabera dagokien tokira mugit
 msgid "description_selector_lookup_translations_policy"
 msgstr "Defektuzko hizkuntza erabiltzen da edukiarentzat eta interfazearentzat."
 
-#. Default: "Set or change the current content language"
-#: ../browser/menu.py:255
+#. Default: "Move the translation under another language folder"
+#: ../browser/menu.py:140
+#, fuzzy
 msgid "description_set_language"
 msgstr "Elementu honen hizkuntza ezarri edo aldatu"
 
-#. Default: "Show the shared Language Independent Folder"
-#: ../browser/menu.py:236
+#. Default: "Open the language independent assets folder"
+#: ../browser/menu.py:445
+#, fuzzy
 msgid "description_shared_folder"
 msgstr "Hizkuntzen artean partekatutako karpeta erakutsi"
 
@@ -275,7 +270,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr "Pausu honek LinguaPloneren elementuen arteko erlazioak sistema berrira migratuko ditu. Pausu honek ez du ezer deusezten eta nahi adina aldiz exekutatu daiteke."
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:102
+#: ../browser/menu.py:166
 msgid "description_translate_into"
 msgstr "${lang_name} hizkuntzara itzuli"
 
@@ -284,8 +279,9 @@ msgstr "${lang_name} hizkuntzara itzuli"
 msgid "description_translation_map"
 msgstr "Itzulpenen mapa"
 
-#. Default: "Universal Language content link"
-#: ../browser/menu.py:215
+#. Default: "Universal link to the content in user's preferred language"
+#: ../browser/menu.py:239
+#, fuzzy
 msgid "description_universal_link"
 msgstr "Elementuaren lotura unibertsala"
 
@@ -295,14 +291,9 @@ msgid "description_update_language"
 msgstr "Uneko elementuaren itzuli gabeko bertsioak"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:159
+#: ../browser/menu.py:112
 msgid "edit_translation"
 msgstr "${lang_name} itzulpena editatu"
-
-#. Default: "Edit ${lang_name} folder"
-#: ../browser/menu.py:155
-msgid "edit_translation_folder"
-msgstr "${lang_name} karpeta editatu"
 
 #. Default: "Folder's id is not a valid language code"
 #: ../browser/migrator.py:308
@@ -410,7 +401,8 @@ msgid "label_connect_translation"
 msgstr "Itzulpena lotu"
 
 #. Default: "General"
-#: ../browser/templates/cleanup.pt:38 ../browser/templates/migration.pt:73
+#: ../browser/templates/cleanup.pt:38
+#: ../browser/templates/migration.pt:73
 msgid "label_general"
 msgstr "Orokorra"
 
@@ -446,12 +438,13 @@ msgid "label_total_relations"
 msgstr "Ukitutako erlazio kopurua:"
 
 #. Default: "Translate"
-#: ../browser/menu.py:276
+#: ../browser/menu.py:491
 msgid "label_translate_menu"
 msgstr "Itzuli..."
 
 #. Default: "Translation Map"
-#: ../browser/templates/cleanup.pt:43 ../browser/templates/migration.pt:78
+#: ../browser/templates/cleanup.pt:43
+#: ../browser/templates/migration.pt:78
 msgid "label_translation_map"
 msgstr "Itzulpen-mapa"
 
@@ -461,7 +454,7 @@ msgid "label_translations_should_be_here"
 msgstr "Elementu honen itzulpenak hemen agertu beharko lirateke"
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:189
+#: ../browser/menu.py:462
 msgid "language_folder"
 msgstr "Hizkuntzaren karpetara joan"
 
@@ -520,8 +513,9 @@ msgstr "Ezin da pausu hau exekutatu LinguaPlone guztiz desinstalatu gabe: produk
 msgid "relation_migration_with_not_needed"
 msgstr "Zure atariak ez du erlazio-kataloorik eta beraz, ez pausu hau ez da beharrezkoa."
 
-#. Default: "Go to Assets folder"
-#: ../browser/menu.py:232
+#. Default: "Open ${title} folder"
+#: ../browser/menu.py:440
+#, fuzzy
 msgid "shared_folder"
 msgstr "Partekatutako karpetara joan"
 
@@ -530,28 +524,35 @@ msgstr "Partekatutako karpetara joan"
 msgid "title_available_languages"
 msgstr "Hizkuntzak"
 
-#. Default: "Edit with babel view"
-#: ../browser/menu.py:66
-msgid "title_babel_edit"
-msgstr "Babel bistarekin editatu"
-
 #. Default: "Language"
 #: ../browser/interfaces.py:54
 msgid "title_language"
 msgstr "Hizkuntza"
 
-#. Default: "Modify translations..."
-#: ../browser/menu.py:167
+#. Default: "Manage translations"
+#: ../browser/menu.py:215
+#, fuzzy
 msgid "title_modify_translations"
 msgstr "Itzulpenak aldatu..."
 
-#. Default: "Set content language"
-#: ../browser/menu.py:251
+#. Default: "Change content language"
+#: ../browser/menu.py:136
+#, fuzzy
 msgid "title_set_language"
 msgstr "Edukiaren hizkuntza ezarri"
 
+#. Default: "Folder translation"
+#: ../browser/menu.py:258
+msgid "title_translate_current_folder"
+msgstr ""
+
+#. Default: "Item translation"
+#: ../browser/menu.py:422
+msgid "title_translate_current_item"
+msgstr ""
+
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:277
+#: ../browser/menu.py:492
 msgid "title_translate_menu"
 msgstr "Zure edukiaren itzulpenak kudeatu."
 
@@ -565,8 +566,9 @@ msgstr "Itzulpenak:"
 msgid "translation_to"
 msgstr "Itzulpena: ${language}"
 
-#. Default: "Universal Link"
-#: ../browser/menu.py:211
+#. Default: "Universal link"
+#: ../browser/menu.py:235
+#, fuzzy
 msgid "universal_link"
 msgstr "Lotura Unibertsala"
 

--- a/src/plone/app/multilingual/locales/fi/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/fi/LC_MESSAGES/plone.app.multilingual.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-07-10 06:24+0000\n"
+"POT-Creation-Date: 2017-07-13 21:35+0000\n"
 "PO-Revision-Date: 2015-02-18 11:45+0200\n"
 "Last-Translator: Asko Soukka <asko.soukka@iki.fi>\n"
 "Language-Team: Finnish <https://github.com/collective>\n"

--- a/src/plone/app/multilingual/locales/fi/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/fi/LC_MESSAGES/plone.app.multilingual.po
@@ -16,15 +16,15 @@ msgstr ""
 
 #: ../browser/migrator.py:85
 msgid "After migration relation cleanup"
-msgstr "Sisältöviittausten korjaus migraation jälkeen"
+msgstr "Korjaa viittaukset sisällössä migraation jälkeen"
 
 #: ../browser/controlpanel.py:62
 msgid "Cancel"
-msgstr ""
+msgstr "Peruuta"
 
 #: ../browser/controlpanel.py:65
 msgid "Changes canceled."
-msgstr ""
+msgstr "Muutokset peruttu."
 
 #: ../browser/templates/cleanup.pt:79
 #: ../browser/templates/migration.pt:250
@@ -33,7 +33,7 @@ msgstr "Siivous"
 
 #: ../browser/controlpanel.py:49
 msgid "Default language not in available languages"
-msgstr ""
+msgstr "Oletuskieli ei ole sallittujen kielten joukossa"
 
 #: ../browser/templates/not_translated_yet.pt:28
 msgid "However, this is the list of the already translated languages for the requested content."
@@ -167,29 +167,19 @@ msgid "create-object-without-translation"
 msgstr "<a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">Haluan luoda tämän sivun, mutta en halua siitä tulevan linkitettyä käännöstä.</a>"
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:122
+#: ../browser/menu.py:161
 msgid "create_translation"
-msgstr "Käännä kielelle ${lang_name}"
-
-#. Default: "Create ${lang_name} folder"
-#: ../browser/menu.py:118
-msgid "create_translation_folder"
-msgstr "Lisää kielikansio kielelle ${lang_name}"
+msgstr "Käännä: ${lang_name}"
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
 #: ../browser/templates/migration.pt:225
 msgid "description_after_migration_cleanup"
 msgstr ""
 
-#. Default: "Edit with the babel_edit"
-#: ../browser/menu.py:70
-msgid "description_babel_edit"
-msgstr "Muokkaa käännösnäkymässä rinnakkain toisen kieliversion kanssa"
-
-#. Default: "Babel edit ${lang_name}"
-#: ../browser/menu.py:139
+#. Default: "Edit {lang_name} with the two-column translation view"
+#: ../browser/menu.py:117
 msgid "description_babeledit_menu"
-msgstr "Muokkaa käännösnäkymässä kieliversiota ${lang_name}"
+msgstr "Muokkaa käännöstä (${lang_name}) kaksipalstaisessa kääntäjässä"
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
 #: ../interfaces.py:240
@@ -212,7 +202,7 @@ msgid "description_google_translation_key"
 msgstr "Maksullinen API-avain Googlen käännöspalvelun käyttöön"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:193
+#: ../browser/menu.py:466
 msgid "description_language_folder"
 msgstr "Siirry käyttäjän selaimen suosittaman kielen kielikansioon"
 
@@ -232,7 +222,7 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:171
+#: ../browser/menu.py:219
 msgid "description_modify_translations"
 msgstr ""
 
@@ -256,16 +246,15 @@ msgstr ""
 msgid "description_selector_lookup_translations_policy"
 msgstr ""
 
-#. Default: "Set or change the current content language"
-#: ../browser/menu.py:255
+#. Default: "Move the translation under another language folder"
+#: ../browser/menu.py:140
 msgid "description_set_language"
-msgstr "Aseta tai vaihda tämän sivun kielimääritys"
+msgstr "Vaihda sisällön kieli ja siirrä sisältö toiselle kielialueelle"
 
-#. Default: "Show the shared Language Independent Folder"
-#: ../browser/menu.py:236
-#, fuzzy
+#. Default: "Open the language independent assets folder"
+#: ../browser/menu.py:445
 msgid "description_shared_folder"
-msgstr "Siirry kieliriippumattoman eli jaetun sisällön kansioon"
+msgstr "Siirry kieliriippumattomaan jaetun sisällön kansioon"
 
 #. Default: "This step will transfer the relations between translations stored by LinguaPlone to the PAM catalog. This step is not destructive and can be executed as many times as needed."
 #: ../browser/templates/migration.pt:195
@@ -273,7 +262,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:102
+#: ../browser/menu.py:166
 msgid "description_translate_into"
 msgstr "Tee tästä sivustä uusi käännös kielelle ${lang_name}"
 
@@ -282,10 +271,10 @@ msgstr "Tee tästä sivustä uusi käännös kielelle ${lang_name}"
 msgid "description_translation_map"
 msgstr "Käännöskartta"
 
-#. Default: "Universal Language content link"
-#: ../browser/menu.py:215
+#. Default: "Universal link to the content in user's preferred language"
+#: ../browser/menu.py:239
 msgid "description_universal_link"
-msgstr "Kieliriippumaton linkki ohjaa suoraan käyttäjän omankieliseen versioon"
+msgstr "Kieliriippumaton linkki ohjaa suoraan käännöseen käyttäjän omalla kielellä"
 
 #. Default: "Untranslated languages from the current content"
 #: ../browser/interfaces.py:63
@@ -293,14 +282,9 @@ msgid "description_update_language"
 msgstr "Kielet, joille tätä sivua ei ole käännetty"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:159
+#: ../browser/menu.py:112
 msgid "edit_translation"
-msgstr "Muokkaa kieltä ${lang_name}"
-
-#. Default: "Edit ${lang_name} folder"
-#: ../browser/menu.py:155
-msgid "edit_translation_folder"
-msgstr "Muokkaa kansiota kielelle ${lang_name}"
+msgstr "Muokkaa: ${lang_name}"
 
 #. Default: "Folder's id is not a valid language code"
 #: ../browser/migrator.py:308
@@ -325,7 +309,7 @@ msgstr "Tämän sivun käännökset"
 #. Default: "Use buttons in the bable view for up to how many translations?"
 #: ../interfaces.py:236
 msgid "heading_buttons_babel_view_up_to_nr_translations"
-msgstr "Kuinka monelle kielelle näyettään painikkeet rinnakkaiskäännösnäkymässä?"
+msgstr "Kuinka monelle kielelle näyettään painikkeet rinnakkaiskääntäjässä?"
 
 #. Default: "Bypass language independent field permission check"
 #: ../interfaces.py:218
@@ -445,9 +429,9 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:276
+#: ../browser/menu.py:491
 msgid "label_translate_menu"
-msgstr ""
+msgstr "Käännä"
 
 #. Default: "Translation Map"
 #: ../browser/templates/cleanup.pt:43
@@ -461,7 +445,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:189
+#: ../browser/menu.py:462
 msgid "language_folder"
 msgstr ""
 
@@ -520,39 +504,43 @@ msgstr ""
 msgid "relation_migration_with_not_needed"
 msgstr ""
 
-#. Default: "Go to Assets folder"
-#: ../browser/menu.py:232
-#, fuzzy
+#. Default: "Open ${title} folder"
+#: ../browser/menu.py:440
 msgid "shared_folder"
-msgstr "Siirry jaettuun kansioon"
+msgstr "Avaa ${title}-kansio"
 
 #. Default: "Available languages"
 #: ../browser/interfaces.py:62
 msgid "title_available_languages"
 msgstr "Kielet"
 
-#. Default: "Edit with babel view"
-#: ../browser/menu.py:66
-msgid "title_babel_edit"
-msgstr "Muokkaa käännösnäkymässä"
-
 #. Default: "Language"
 #: ../browser/interfaces.py:54
 msgid "title_language"
 msgstr "Kieli"
 
-#. Default: "Modify translations..."
-#: ../browser/menu.py:167
+#. Default: "Manage translations"
+#: ../browser/menu.py:215
 msgid "title_modify_translations"
-msgstr ""
+msgstr "Hallitse käännöksiä"
 
-#. Default: "Set content language"
-#: ../browser/menu.py:251
+#. Default: "Change content language"
+#: ../browser/menu.py:136
 msgid "title_set_language"
 msgstr "Määritä tämän sivun kieli"
 
+#. Default: "Folder translation"
+#: ../browser/menu.py:258
+msgid "title_translate_current_folder"
+msgstr "Kansion käännökset"
+
+#. Default: "Item translation"
+#: ../browser/menu.py:422
+msgid "title_translate_current_item"
+msgstr "Sivun käännökset"
+
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:277
+#: ../browser/menu.py:492
 msgid "title_translate_menu"
 msgstr "Hallitse käännöksiä"
 
@@ -566,8 +554,8 @@ msgstr "Käännökset"
 msgid "translation_to"
 msgstr "Käännös kielelle ${language}"
 
-#. Default: "Universal Link"
-#: ../browser/menu.py:211
+#. Default: "Universal link"
+#: ../browser/menu.py:235
 msgid "universal_link"
 msgstr "Kieliriippumaton linkki"
 

--- a/src/plone/app/multilingual/locales/fr/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/fr/LC_MESSAGES/plone.app.multilingual.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.2b3\n"
-"POT-Creation-Date: 2017-07-10 06:24+0000\n"
+"POT-Creation-Date: 2017-07-13 21:35+0000\n"
 "PO-Revision-Date: 2015-09-16 01:58+0100\n"
 "Last-Translator: Encolpe DEGOUTE <encolpe.degoute@free.fr>\n"
 "Language-Team: Plone-fr <plone-fr@lists.plone.org>\n"
@@ -170,27 +170,18 @@ msgid "create-object-without-translation"
 msgstr "Si vous souhaité créer cet élément sans rentrer dans le processus de traduction cliquez <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">ici</a>"
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:122
+#: ../browser/menu.py:161
 msgid "create_translation"
 msgstr "Créer ${lang_name}"
-
-#. Default: "Create ${lang_name} folder"
-#: ../browser/menu.py:118
-msgid "create_translation_folder"
-msgstr "Créer le dossier ${lang_name}"
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
 #: ../browser/templates/migration.pt:225
 msgid "description_after_migration_cleanup"
 msgstr "Cet migration fixera les dépendances perdues à l'interface ITranslatable cachée dans le catalogue des relations et les supprimera. Elle doit être executée seulement une fois que LinguaPlone a été complètement désinstallé."
 
-#. Default: "Edit with the babel_edit"
-#: ../browser/menu.py:70
-msgid "description_babel_edit"
-msgstr "Modifier avec la vue babel"
-
-#. Default: "Babel edit ${lang_name}"
-#: ../browser/menu.py:139
+#. Default: "Edit {lang_name} with the two-column translation view"
+#: ../browser/menu.py:117
+#, fuzzy
 msgid "description_babeledit_menu"
 msgstr "Modifier (Babel) ${lang_name}"
 
@@ -215,7 +206,7 @@ msgid "description_google_translation_key"
 msgstr "C'est une API payante pour utiliser le service de traduction de Google"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:193
+#: ../browser/menu.py:466
 msgid "description_language_folder"
 msgstr "Aller dans le dossier indiqué par la langue préférée du navigateur de l'utilisateur"
 
@@ -235,7 +226,7 @@ msgid "description_migration_results"
 msgstr "Vous verrez ici les résultats de la migration"
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:171
+#: ../browser/menu.py:219
 msgid "description_modify_translations"
 msgstr ""
 
@@ -259,13 +250,14 @@ msgstr "Cet étape de migration déplacera le contenu dans le dossier racine du 
 msgid "description_selector_lookup_translations_policy"
 msgstr "La langue par défaut pour le contenu et les interfaces de ce site."
 
-#. Default: "Set or change the current content language"
-#: ../browser/menu.py:255
+#. Default: "Move the translation under another language folder"
+#: ../browser/menu.py:140
+#, fuzzy
 msgid "description_set_language"
 msgstr "Préciser ou modifier la langue actuelle du contenu"
 
-#. Default: "Show the shared Language Independent Folder"
-#: ../browser/menu.py:236
+#. Default: "Open the language independent assets folder"
+#: ../browser/menu.py:445
 #, fuzzy
 msgid "description_shared_folder"
 msgstr "Afficher le dossier partagé (langue neutre)"
@@ -276,7 +268,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr "Cette étape transfèrera les relations entre les traductions stoquées par LinguaPlone dans le catalog de PAM. Cette étape n'est pas destructive est peut être executée autant que nécessaire."
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:102
+#: ../browser/menu.py:166
 msgid "description_translate_into"
 msgstr "Traduire en ${lang_name}"
 
@@ -285,8 +277,9 @@ msgstr "Traduire en ${lang_name}"
 msgid "description_translation_map"
 msgstr "Liste des traductions."
 
-#. Default: "Universal Language content link"
-#: ../browser/menu.py:215
+#. Default: "Universal link to the content in user's preferred language"
+#: ../browser/menu.py:239
+#, fuzzy
 msgid "description_universal_link"
 msgstr "Lien universel du contenu (langue automatique)"
 
@@ -296,14 +289,9 @@ msgid "description_update_language"
 msgstr "Langues non traduites pour ce contenu"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:159
+#: ../browser/menu.py:112
 msgid "edit_translation"
 msgstr "Modifier ${lang_name}"
-
-#. Default: "Edit ${lang_name} folder"
-#: ../browser/menu.py:155
-msgid "edit_translation_folder"
-msgstr "Modifier le dossier ${lang_name}"
 
 #. Default: "Folder's id is not a valid language code"
 #: ../browser/migrator.py:308
@@ -448,7 +436,7 @@ msgid "label_total_relations"
 msgstr "Nombre total de relation mises à jour :"
 
 #. Default: "Translate"
-#: ../browser/menu.py:276
+#: ../browser/menu.py:491
 msgid "label_translate_menu"
 msgstr "Traduire"
 
@@ -464,7 +452,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:189
+#: ../browser/menu.py:462
 msgid "language_folder"
 msgstr "Revenir au dossier de langue"
 
@@ -523,8 +511,8 @@ msgstr "Il n'est pas possible d'exécuter cette étape de migration sans désins
 msgid "relation_migration_with_not_needed"
 msgstr "Votre site n'a pas de catalogue de relations, et dans ce cas cette étape de migration n'est pas nécessaire"
 
-#. Default: "Go to Assets folder"
-#: ../browser/menu.py:232
+#. Default: "Open ${title} folder"
+#: ../browser/menu.py:440
 #, fuzzy
 msgid "shared_folder"
 msgstr "Aller au dossier partagé"
@@ -534,28 +522,34 @@ msgstr "Aller au dossier partagé"
 msgid "title_available_languages"
 msgstr "Langues disponibles"
 
-#. Default: "Edit with babel view"
-#: ../browser/menu.py:66
-msgid "title_babel_edit"
-msgstr "Modifier avec la vue babel"
-
 #. Default: "Language"
 #: ../browser/interfaces.py:54
 msgid "title_language"
 msgstr "Langue"
 
-#. Default: "Modify translations..."
-#: ../browser/menu.py:167
+#. Default: "Manage translations"
+#: ../browser/menu.py:215
 msgid "title_modify_translations"
 msgstr ""
 
-#. Default: "Set content language"
-#: ../browser/menu.py:251
+#. Default: "Change content language"
+#: ../browser/menu.py:136
+#, fuzzy
 msgid "title_set_language"
 msgstr "Définir la langue du contenu"
 
+#. Default: "Folder translation"
+#: ../browser/menu.py:258
+msgid "title_translate_current_folder"
+msgstr ""
+
+#. Default: "Item translation"
+#: ../browser/menu.py:422
+msgid "title_translate_current_item"
+msgstr ""
+
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:277
+#: ../browser/menu.py:492
 msgid "title_translate_menu"
 msgstr "Gérer les traductions du contenu"
 
@@ -569,8 +563,9 @@ msgstr "Traductions :"
 msgid "translation_to"
 msgstr "Traduire en ${language}"
 
-#. Default: "Universal Link"
-#: ../browser/menu.py:211
+#. Default: "Universal link"
+#: ../browser/menu.py:235
+#, fuzzy
 msgid "universal_link"
 msgstr "Lien universel"
 

--- a/src/plone/app/multilingual/locales/it/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/it/LC_MESSAGES/plone.app.multilingual.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.2b3\n"
-"POT-Creation-Date: 2017-07-10 06:24+0000\n"
+"POT-Creation-Date: 2017-07-13 21:35+0000\n"
 "PO-Revision-Date: 2013-10-08 09:30+0000\n"
 "Last-Translator: Giorgio Borelli <giorgio@giorgioborelli.it>\n"
 "Language-Team: Plone italian translation group <plone-italian-translation-discussion@lists.coactivate.org>\n"
@@ -169,27 +169,18 @@ msgid "create-object-without-translation"
 msgstr "Se vuoi creare l'oggetto senza che sia la traduzione del contenuto originario clicca <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">qui</a>"
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:122
+#: ../browser/menu.py:161
 msgid "create_translation"
 msgstr "Crea ${lang_name}"
-
-#. Default: "Create ${lang_name} folder"
-#: ../browser/menu.py:118
-msgid "create_translation_folder"
-msgstr "Crea la cartella ${lang_name}"
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
 #: ../browser/templates/migration.pt:225
 msgid "description_after_migration_cleanup"
 msgstr ""
 
-#. Default: "Edit with the babel_edit"
-#: ../browser/menu.py:70
-msgid "description_babel_edit"
-msgstr "Modifica le traduzioni con 'babel edit'"
-
-#. Default: "Babel edit ${lang_name}"
-#: ../browser/menu.py:139
+#. Default: "Edit {lang_name} with the two-column translation view"
+#: ../browser/menu.py:117
+#, fuzzy
 msgid "description_babeledit_menu"
 msgstr "Babel edit ${lang_name}"
 
@@ -214,7 +205,7 @@ msgid "description_google_translation_key"
 msgstr "Queste sono delle API a pagamento per utilizzare il servizio di traduzione di Google"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:193
+#: ../browser/menu.py:466
 msgid "description_language_folder"
 msgstr ""
 
@@ -234,7 +225,7 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:171
+#: ../browser/menu.py:219
 msgid "description_modify_translations"
 msgstr ""
 
@@ -258,13 +249,14 @@ msgstr ""
 msgid "description_selector_lookup_translations_policy"
 msgstr "La lingua di default usata per i contenuti e la UI del sito."
 
-#. Default: "Set or change the current content language"
-#: ../browser/menu.py:255
+#. Default: "Move the translation under another language folder"
+#: ../browser/menu.py:140
+#, fuzzy
 msgid "description_set_language"
 msgstr "Imposta o cambia la lingua corrente di questo contenuto."
 
-#. Default: "Show the shared Language Independent Folder"
-#: ../browser/menu.py:236
+#. Default: "Open the language independent assets folder"
+#: ../browser/menu.py:445
 #, fuzzy
 msgid "description_shared_folder"
 msgstr "Visualizza la cartella condivisa tra le lingue (in lingua neutra)"
@@ -275,7 +267,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:102
+#: ../browser/menu.py:166
 msgid "description_translate_into"
 msgstr "Traduci in ${lang_name}"
 
@@ -284,8 +276,9 @@ msgstr "Traduci in ${lang_name}"
 msgid "description_translation_map"
 msgstr "Mappa traduzioni"
 
-#. Default: "Universal Language content link"
-#: ../browser/menu.py:215
+#. Default: "Universal link to the content in user's preferred language"
+#: ../browser/menu.py:239
+#, fuzzy
 msgid "description_universal_link"
 msgstr "Link universale indipendente dalla lingua"
 
@@ -295,14 +288,9 @@ msgid "description_update_language"
 msgstr "Lingue in cui il contenuto non è ancora stato tradotto"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:159
+#: ../browser/menu.py:112
 msgid "edit_translation"
 msgstr "Modifica ${lang_name}"
-
-#. Default: "Edit ${lang_name} folder"
-#: ../browser/menu.py:155
-msgid "edit_translation_folder"
-msgstr "Modifica cartella ${lang_name}"
 
 #. Default: "Folder's id is not a valid language code"
 #: ../browser/migrator.py:308
@@ -447,7 +435,7 @@ msgid "label_total_relations"
 msgstr "Numero di relazioni interessate:"
 
 #. Default: "Translate"
-#: ../browser/menu.py:276
+#: ../browser/menu.py:491
 msgid "label_translate_menu"
 msgstr "Traduci"
 
@@ -463,7 +451,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:189
+#: ../browser/menu.py:462
 msgid "language_folder"
 msgstr "Ritorna alla cartella lingua"
 
@@ -522,8 +510,8 @@ msgstr ""
 msgid "relation_migration_with_not_needed"
 msgstr ""
 
-#. Default: "Go to Assets folder"
-#: ../browser/menu.py:232
+#. Default: "Open ${title} folder"
+#: ../browser/menu.py:440
 #, fuzzy
 msgid "shared_folder"
 msgstr "Vai alla cartella condivisa"
@@ -533,28 +521,34 @@ msgstr "Vai alla cartella condivisa"
 msgid "title_available_languages"
 msgstr "Lingue disponibili"
 
-#. Default: "Edit with babel view"
-#: ../browser/menu.py:66
-msgid "title_babel_edit"
-msgstr "Modifica con 'babel view'"
-
 #. Default: "Language"
 #: ../browser/interfaces.py:54
 msgid "title_language"
 msgstr "Lingue"
 
-#. Default: "Modify translations..."
-#: ../browser/menu.py:167
+#. Default: "Manage translations"
+#: ../browser/menu.py:215
 msgid "title_modify_translations"
 msgstr ""
 
-#. Default: "Set content language"
-#: ../browser/menu.py:251
+#. Default: "Change content language"
+#: ../browser/menu.py:136
+#, fuzzy
 msgid "title_set_language"
 msgstr "Imposta la lingua del contenuto"
 
+#. Default: "Folder translation"
+#: ../browser/menu.py:258
+msgid "title_translate_current_folder"
+msgstr ""
+
+#. Default: "Item translation"
+#: ../browser/menu.py:422
+msgid "title_translate_current_item"
+msgstr ""
+
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:277
+#: ../browser/menu.py:492
 msgid "title_translate_menu"
 msgstr "Gestisci le traduzioni del contenuto"
 
@@ -568,8 +562,9 @@ msgstr "Traduzioni:"
 msgid "translation_to"
 msgstr "Traduci in ${language}"
 
-#. Default: "Universal Link"
-#: ../browser/menu.py:211
+#. Default: "Universal link"
+#: ../browser/menu.py:235
+#, fuzzy
 msgid "universal_link"
 msgstr "Link universale"
 

--- a/src/plone/app/multilingual/locales/ja/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/ja/LC_MESSAGES/plone.app.multilingual.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.2b3\n"
-"POT-Creation-Date: 2017-07-10 06:24+0000\n"
+"POT-Creation-Date: 2017-07-13 21:35+0000\n"
 "PO-Revision-Date: 2015-04-29 14:51+0900\n"
 "Last-Translator: Manabu TERADA <terada@cmscom.jp>\n"
 "Language-Team: Plone Japanese Team <https://github.com/plonejp>\n"
@@ -169,13 +169,8 @@ msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:122
+#: ../browser/menu.py:161
 msgid "create_translation"
-msgstr ""
-
-#. Default: "Create ${lang_name} folder"
-#: ../browser/menu.py:118
-msgid "create_translation_folder"
 msgstr ""
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
@@ -183,13 +178,8 @@ msgstr ""
 msgid "description_after_migration_cleanup"
 msgstr ""
 
-#. Default: "Edit with the babel_edit"
-#: ../browser/menu.py:70
-msgid "description_babel_edit"
-msgstr ""
-
-#. Default: "Babel edit ${lang_name}"
-#: ../browser/menu.py:139
+#. Default: "Edit {lang_name} with the two-column translation view"
+#: ../browser/menu.py:117
 msgid "description_babeledit_menu"
 msgstr ""
 
@@ -214,7 +204,7 @@ msgid "description_google_translation_key"
 msgstr ""
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:193
+#: ../browser/menu.py:466
 msgid "description_language_folder"
 msgstr ""
 
@@ -234,7 +224,7 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:171
+#: ../browser/menu.py:219
 msgid "description_modify_translations"
 msgstr ""
 
@@ -258,13 +248,13 @@ msgstr ""
 msgid "description_selector_lookup_translations_policy"
 msgstr ""
 
-#. Default: "Set or change the current content language"
-#: ../browser/menu.py:255
+#. Default: "Move the translation under another language folder"
+#: ../browser/menu.py:140
 msgid "description_set_language"
 msgstr ""
 
-#. Default: "Show the shared Language Independent Folder"
-#: ../browser/menu.py:236
+#. Default: "Open the language independent assets folder"
+#: ../browser/menu.py:445
 msgid "description_shared_folder"
 msgstr ""
 
@@ -274,7 +264,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:102
+#: ../browser/menu.py:166
 msgid "description_translate_into"
 msgstr "${lang_name}に翻訳"
 
@@ -283,8 +273,8 @@ msgstr "${lang_name}に翻訳"
 msgid "description_translation_map"
 msgstr ""
 
-#. Default: "Universal Language content link"
-#: ../browser/menu.py:215
+#. Default: "Universal link to the content in user's preferred language"
+#: ../browser/menu.py:239
 msgid "description_universal_link"
 msgstr ""
 
@@ -294,13 +284,8 @@ msgid "description_update_language"
 msgstr ""
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:159
+#: ../browser/menu.py:112
 msgid "edit_translation"
-msgstr ""
-
-#. Default: "Edit ${lang_name} folder"
-#: ../browser/menu.py:155
-msgid "edit_translation_folder"
 msgstr ""
 
 #. Default: "Folder's id is not a valid language code"
@@ -446,7 +431,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:276
+#: ../browser/menu.py:491
 #, fuzzy
 msgid "label_translate_menu"
 msgstr "翻訳する"
@@ -463,7 +448,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:189
+#: ../browser/menu.py:462
 msgid "language_folder"
 msgstr ""
 
@@ -522,8 +507,8 @@ msgstr ""
 msgid "relation_migration_with_not_needed"
 msgstr ""
 
-#. Default: "Go to Assets folder"
-#: ../browser/menu.py:232
+#. Default: "Open ${title} folder"
+#: ../browser/menu.py:440
 msgid "shared_folder"
 msgstr ""
 
@@ -532,28 +517,33 @@ msgstr ""
 msgid "title_available_languages"
 msgstr ""
 
-#. Default: "Edit with babel view"
-#: ../browser/menu.py:66
-msgid "title_babel_edit"
-msgstr ""
-
 #. Default: "Language"
 #: ../browser/interfaces.py:54
 msgid "title_language"
 msgstr "言語"
 
-#. Default: "Modify translations..."
-#: ../browser/menu.py:167
+#. Default: "Manage translations"
+#: ../browser/menu.py:215
 msgid "title_modify_translations"
 msgstr ""
 
-#. Default: "Set content language"
-#: ../browser/menu.py:251
+#. Default: "Change content language"
+#: ../browser/menu.py:136
 msgid "title_set_language"
 msgstr ""
 
+#. Default: "Folder translation"
+#: ../browser/menu.py:258
+msgid "title_translate_current_folder"
+msgstr ""
+
+#. Default: "Item translation"
+#: ../browser/menu.py:422
+msgid "title_translate_current_item"
+msgstr ""
+
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:277
+#: ../browser/menu.py:492
 msgid "title_translate_menu"
 msgstr "コンテンツの翻訳を管理"
 
@@ -567,8 +557,8 @@ msgstr ""
 msgid "translation_to"
 msgstr ""
 
-#. Default: "Universal Link"
-#: ../browser/menu.py:211
+#. Default: "Universal link"
+#: ../browser/menu.py:235
 msgid "universal_link"
 msgstr ""
 

--- a/src/plone/app/multilingual/locales/nl/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/nl/LC_MESSAGES/plone.app.multilingual.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone.app.multilingual\n"
-"POT-Creation-Date: 2017-07-10 06:24+0000\n"
+"POT-Creation-Date: 2017-07-13 21:35+0000\n"
 "PO-Revision-Date: 2017-02-28 10:22+0100\n"
 "Last-Translator: Jean-Paul Ladage <j.ladage@zestsoftware.nl>\n"
 "Language-Team: Nederlands <translators@plone.nl>\n"
@@ -169,27 +169,18 @@ msgid "create-object-without-translation"
 msgstr "Als u dit item wilt aanmaken zonder vertaling <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">klik hier</a>"
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:122
+#: ../browser/menu.py:161
 msgid "create_translation"
 msgstr "${lang_name} aanmaken"
-
-#. Default: "Create ${lang_name} folder"
-#: ../browser/menu.py:118
-msgid "create_translation_folder"
-msgstr "Map ${lang_name} aanmaken"
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
 #: ../browser/templates/migration.pt:225
 msgid "description_after_migration_cleanup"
 msgstr "Deze stap wil hersteld enkele vertalingen en schoont de catalogus op. Alleen uitvoeren als LinguaPlone al actief is"
 
-#. Default: "Edit with the babel_edit"
-#: ../browser/menu.py:70
-msgid "description_babel_edit"
-msgstr "Bewerken met Babel "
-
-#. Default: "Babel edit ${lang_name}"
-#: ../browser/menu.py:139
+#. Default: "Edit {lang_name} with the two-column translation view"
+#: ../browser/menu.py:117
+#, fuzzy
 msgid "description_babeledit_menu"
 msgstr "${lang_name} bewerken met Babel"
 
@@ -214,7 +205,7 @@ msgid "description_google_translation_key"
 msgstr "Google Translation API Key"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:193
+#: ../browser/menu.py:466
 msgid "description_language_folder"
 msgstr "Ga terug naar de taalafhankelijke map"
 
@@ -234,7 +225,7 @@ msgid "description_migration_results"
 msgstr "Hier ziet u de resultaten van het migratieproces."
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:171
+#: ../browser/menu.py:219
 msgid "description_modify_translations"
 msgstr "Vertalingen toevoegen of verwijderen"
 
@@ -258,13 +249,15 @@ msgstr "Deze stap zal de inhoud verplaatsen naar de overeenkomstige talen waarmo
 msgid "description_selector_lookup_translations_policy"
 msgstr "De standaardtaal wordt gebruikt voor de inhoud en de UI van deze site."
 
-#. Default: "Set or change the current content language"
-#: ../browser/menu.py:255
+#. Default: "Move the translation under another language folder"
+#: ../browser/menu.py:140
+#, fuzzy
 msgid "description_set_language"
 msgstr "Huidige taal instellen of wijzigen"
 
-#. Default: "Show the shared Language Independent Folder"
-#: ../browser/menu.py:236
+#. Default: "Open the language independent assets folder"
+#: ../browser/menu.py:445
+#, fuzzy
 msgid "description_shared_folder"
 msgstr "Toon de gedeelde taalonafhankelijke map"
 
@@ -274,7 +267,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr "Deze stap de relaties tussen vertalingen overzetten naar de PAM catalogus. Deze stap breekt niets en kan meerdere keren uitgevoerd worden."
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:102
+#: ../browser/menu.py:166
 msgid "description_translate_into"
 msgstr "Vertaal naar ${lang_name}"
 
@@ -283,8 +276,9 @@ msgstr "Vertaal naar ${lang_name}"
 msgid "description_translation_map"
 msgstr "Vertaaloverzicht"
 
-#. Default: "Universal Language content link"
-#: ../browser/menu.py:215
+#. Default: "Universal link to the content in user's preferred language"
+#: ../browser/menu.py:239
+#, fuzzy
 msgid "description_universal_link"
 msgstr "Universele taal link"
 
@@ -294,14 +288,9 @@ msgid "description_update_language"
 msgstr "Ontbrekende vertalingen voor dit item"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:159
+#: ../browser/menu.py:112
 msgid "edit_translation"
 msgstr "${lang_name} bewerken"
-
-#. Default: "Edit ${lang_name} folder"
-#: ../browser/menu.py:155
-msgid "edit_translation_folder"
-msgstr "${lang_name} map bewerken"
 
 #. Default: "Folder's id is not a valid language code"
 #: ../browser/migrator.py:308
@@ -446,7 +435,7 @@ msgid "label_total_relations"
 msgstr "Aantal aangepaste koppelingen"
 
 #. Default: "Translate"
-#: ../browser/menu.py:276
+#: ../browser/menu.py:491
 msgid "label_translate_menu"
 msgstr "Vertalen"
 
@@ -462,7 +451,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:189
+#: ../browser/menu.py:462
 msgid "language_folder"
 msgstr "Terug naar taalmap"
 
@@ -521,8 +510,8 @@ msgstr "Het is niet mogelijk om deze stap uit te voeren voordat LinguaPlone comp
 msgid "relation_migration_with_not_needed"
 msgstr "Uw website heeft geen relatie catalogus, deze migratie-stap in niet nodig."
 
-#. Default: "Go to Assets folder"
-#: ../browser/menu.py:232
+#. Default: "Open ${title} folder"
+#: ../browser/menu.py:440
 #, fuzzy
 msgid "shared_folder"
 msgstr "Ga naar Media map"
@@ -532,28 +521,35 @@ msgstr "Ga naar Media map"
 msgid "title_available_languages"
 msgstr "Beschikbare talen"
 
-#. Default: "Edit with babel view"
-#: ../browser/menu.py:66
-msgid "title_babel_edit"
-msgstr "Bewerken met babel weergave"
-
 #. Default: "Language"
 #: ../browser/interfaces.py:54
 msgid "title_language"
 msgstr "Taal"
 
-#. Default: "Modify translations..."
-#: ../browser/menu.py:167
+#. Default: "Manage translations"
+#: ../browser/menu.py:215
+#, fuzzy
 msgid "title_modify_translations"
 msgstr "Vertalingen aanpassen"
 
-#. Default: "Set content language"
-#: ../browser/menu.py:251
+#. Default: "Change content language"
+#: ../browser/menu.py:136
+#, fuzzy
 msgid "title_set_language"
 msgstr "Taal instellen"
 
+#. Default: "Folder translation"
+#: ../browser/menu.py:258
+msgid "title_translate_current_folder"
+msgstr ""
+
+#. Default: "Item translation"
+#: ../browser/menu.py:422
+msgid "title_translate_current_item"
+msgstr ""
+
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:277
+#: ../browser/menu.py:492
 msgid "title_translate_menu"
 msgstr "Talen beheren voor uw inhoud"
 
@@ -567,8 +563,9 @@ msgstr "Vertalingen:"
 msgid "translation_to"
 msgstr "Vertaling naar ${language}"
 
-#. Default: "Universal Link"
-#: ../browser/menu.py:211
+#. Default: "Universal link"
+#: ../browser/menu.py:235
+#, fuzzy
 msgid "universal_link"
 msgstr "Universele link"
 

--- a/src/plone/app/multilingual/locales/pl/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/pl/LC_MESSAGES/plone.app.multilingual.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone.app.multilingual\n"
-"POT-Creation-Date: 2017-07-10 06:24+0000\n"
+"POT-Creation-Date: 2017-07-13 21:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Radek Jankiewicz <radoslaw.jankiewicz@gmail.com>\n"
 "Language-Team: plone-cat <plone-cat@plone.org>\n"
@@ -167,13 +167,8 @@ msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:122
+#: ../browser/menu.py:161
 msgid "create_translation"
-msgstr ""
-
-#. Default: "Create ${lang_name} folder"
-#: ../browser/menu.py:118
-msgid "create_translation_folder"
 msgstr ""
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
@@ -181,13 +176,9 @@ msgstr ""
 msgid "description_after_migration_cleanup"
 msgstr ""
 
-#. Default: "Edit with the babel_edit"
-#: ../browser/menu.py:70
-msgid "description_babel_edit"
-msgstr "Edytuj używając 'Babel'"
-
-#. Default: "Babel edit ${lang_name}"
-#: ../browser/menu.py:139
+#. Default: "Edit {lang_name} with the two-column translation view"
+#: ../browser/menu.py:117
+#, fuzzy
 msgid "description_babeledit_menu"
 msgstr "Edytuj przy użyciu 'Babel': ${lang_name}"
 
@@ -212,7 +203,7 @@ msgid "description_google_translation_key"
 msgstr "Klucz API do serwisu Google Translation"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:193
+#: ../browser/menu.py:466
 msgid "description_language_folder"
 msgstr "Przejdź do folderu zgodnego z ustawieniami językowymi przeglądarki użytkownika"
 
@@ -233,7 +224,7 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:171
+#: ../browser/menu.py:219
 msgid "description_modify_translations"
 msgstr ""
 
@@ -257,13 +248,14 @@ msgstr ""
 msgid "description_selector_lookup_translations_policy"
 msgstr "Domyślny język, w którym tworzona jest treść i wyświetlany jest interfejs użytkownika."
 
-#. Default: "Set or change the current content language"
-#: ../browser/menu.py:255
+#. Default: "Move the translation under another language folder"
+#: ../browser/menu.py:140
+#, fuzzy
 msgid "description_set_language"
 msgstr "Ustaw lub zmień obecny język treści"
 
-#. Default: "Show the shared Language Independent Folder"
-#: ../browser/menu.py:236
+#. Default: "Open the language independent assets folder"
+#: ../browser/menu.py:445
 #, fuzzy
 msgid "description_shared_folder"
 msgstr "Wyświetlaj folder zawierający treść w języku neutralnym"
@@ -274,7 +266,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:102
+#: ../browser/menu.py:166
 msgid "description_translate_into"
 msgstr "Przetłumacz na ${lang_name}"
 
@@ -283,8 +275,9 @@ msgstr "Przetłumacz na ${lang_name}"
 msgid "description_translation_map"
 msgstr "Mapa tłumaczeń."
 
-#. Default: "Universal Language content link"
-#: ../browser/menu.py:215
+#. Default: "Universal link to the content in user's preferred language"
+#: ../browser/menu.py:239
+#, fuzzy
 msgid "description_universal_link"
 msgstr "Uniwersalny link do danego obiektu, wyświetlający jego wersję językową zgodną z ustawiwniami językowymi przeglądadki użytkownika"
 
@@ -294,13 +287,8 @@ msgid "description_update_language"
 msgstr "Nieprzetłumaczone języki dla tego obiektu"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:159
+#: ../browser/menu.py:112
 msgid "edit_translation"
-msgstr ""
-
-#. Default: "Edit ${lang_name} folder"
-#: ../browser/menu.py:155
-msgid "edit_translation_folder"
 msgstr ""
 
 #. Default: "Folder's id is not a valid language code"
@@ -446,7 +434,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:276
+#: ../browser/menu.py:491
 msgid "label_translate_menu"
 msgstr "Tłumacz"
 
@@ -462,7 +450,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:189
+#: ../browser/menu.py:462
 msgid "language_folder"
 msgstr "Wróć do folderu języka"
 
@@ -521,8 +509,8 @@ msgstr ""
 msgid "relation_migration_with_not_needed"
 msgstr ""
 
-#. Default: "Go to Assets folder"
-#: ../browser/menu.py:232
+#. Default: "Open ${title} folder"
+#: ../browser/menu.py:440
 #, fuzzy
 msgid "shared_folder"
 msgstr "Przejdź do folderu współdzielonego"
@@ -532,28 +520,34 @@ msgstr "Przejdź do folderu współdzielonego"
 msgid "title_available_languages"
 msgstr "Dostępne języki"
 
-#. Default: "Edit with babel view"
-#: ../browser/menu.py:66
-msgid "title_babel_edit"
-msgstr "Edytuj przy użyciu Babel"
-
 #. Default: "Language"
 #: ../browser/interfaces.py:54
 msgid "title_language"
 msgstr "Język"
 
-#. Default: "Modify translations..."
-#: ../browser/menu.py:167
+#. Default: "Manage translations"
+#: ../browser/menu.py:215
 msgid "title_modify_translations"
 msgstr ""
 
-#. Default: "Set content language"
-#: ../browser/menu.py:251
+#. Default: "Change content language"
+#: ../browser/menu.py:136
+#, fuzzy
 msgid "title_set_language"
 msgstr "Ustaw język treści"
 
+#. Default: "Folder translation"
+#: ../browser/menu.py:258
+msgid "title_translate_current_folder"
+msgstr ""
+
+#. Default: "Item translation"
+#: ../browser/menu.py:422
+msgid "title_translate_current_item"
+msgstr ""
+
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:277
+#: ../browser/menu.py:492
 msgid "title_translate_menu"
 msgstr "Zarządzaj tłumaczeniami obiektu"
 
@@ -567,8 +561,9 @@ msgstr "Wersje językowe:"
 msgid "translation_to"
 msgstr "Tłumaczenie na ${language}"
 
-#. Default: "Universal Link"
-#: ../browser/menu.py:211
+#. Default: "Universal link"
+#: ../browser/menu.py:235
+#, fuzzy
 msgid "universal_link"
 msgstr "Link uniwersalny"
 

--- a/src/plone/app/multilingual/locales/plone.app.multilingual.pot
+++ b/src/plone/app/multilingual/locales/plone.app.multilingual.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-07-10 06:24+0000\n"
+"POT-Creation-Date: 2017-07-13 21:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -170,13 +170,8 @@ msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:122
+#: ../browser/menu.py:161
 msgid "create_translation"
-msgstr ""
-
-#. Default: "Create ${lang_name} folder"
-#: ../browser/menu.py:118
-msgid "create_translation_folder"
 msgstr ""
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
@@ -184,13 +179,8 @@ msgstr ""
 msgid "description_after_migration_cleanup"
 msgstr ""
 
-#. Default: "Edit with the babel_edit"
-#: ../browser/menu.py:70
-msgid "description_babel_edit"
-msgstr ""
-
-#. Default: "Babel edit ${lang_name}"
-#: ../browser/menu.py:139
+#. Default: "Edit {lang_name} with the two-column translation view"
+#: ../browser/menu.py:117
 msgid "description_babeledit_menu"
 msgstr ""
 
@@ -215,7 +205,7 @@ msgid "description_google_translation_key"
 msgstr ""
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:193
+#: ../browser/menu.py:466
 msgid "description_language_folder"
 msgstr ""
 
@@ -235,7 +225,7 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:171
+#: ../browser/menu.py:219
 msgid "description_modify_translations"
 msgstr ""
 
@@ -259,13 +249,13 @@ msgstr ""
 msgid "description_selector_lookup_translations_policy"
 msgstr ""
 
-#. Default: "Set or change the current content language"
-#: ../browser/menu.py:255
+#. Default: "Move the translation under another language folder"
+#: ../browser/menu.py:140
 msgid "description_set_language"
 msgstr ""
 
-#. Default: "Show the shared Language Independent Folder"
-#: ../browser/menu.py:236
+#. Default: "Open the language independent assets folder"
+#: ../browser/menu.py:445
 msgid "description_shared_folder"
 msgstr ""
 
@@ -275,7 +265,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:102
+#: ../browser/menu.py:166
 msgid "description_translate_into"
 msgstr ""
 
@@ -284,8 +274,8 @@ msgstr ""
 msgid "description_translation_map"
 msgstr ""
 
-#. Default: "Universal Language content link"
-#: ../browser/menu.py:215
+#. Default: "Universal link to the content in user's preferred language"
+#: ../browser/menu.py:239
 msgid "description_universal_link"
 msgstr ""
 
@@ -295,13 +285,8 @@ msgid "description_update_language"
 msgstr ""
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:159
+#: ../browser/menu.py:112
 msgid "edit_translation"
-msgstr ""
-
-#. Default: "Edit ${lang_name} folder"
-#: ../browser/menu.py:155
-msgid "edit_translation_folder"
 msgstr ""
 
 #. Default: "Folder's id is not a valid language code"
@@ -447,7 +432,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:276
+#: ../browser/menu.py:491
 msgid "label_translate_menu"
 msgstr ""
 
@@ -463,7 +448,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:189
+#: ../browser/menu.py:462
 msgid "language_folder"
 msgstr ""
 
@@ -522,8 +507,8 @@ msgstr ""
 msgid "relation_migration_with_not_needed"
 msgstr ""
 
-#. Default: "Go to Assets folder"
-#: ../browser/menu.py:232
+#. Default: "Open ${title} folder"
+#: ../browser/menu.py:440
 msgid "shared_folder"
 msgstr ""
 
@@ -532,28 +517,33 @@ msgstr ""
 msgid "title_available_languages"
 msgstr ""
 
-#. Default: "Edit with babel view"
-#: ../browser/menu.py:66
-msgid "title_babel_edit"
-msgstr ""
-
 #. Default: "Language"
 #: ../browser/interfaces.py:54
 msgid "title_language"
 msgstr ""
 
-#. Default: "Modify translations..."
-#: ../browser/menu.py:167
+#. Default: "Manage translations"
+#: ../browser/menu.py:215
 msgid "title_modify_translations"
 msgstr ""
 
-#. Default: "Set content language"
-#: ../browser/menu.py:251
+#. Default: "Change content language"
+#: ../browser/menu.py:136
 msgid "title_set_language"
 msgstr ""
 
+#. Default: "Folder translation"
+#: ../browser/menu.py:258
+msgid "title_translate_current_folder"
+msgstr ""
+
+#. Default: "Item translation"
+#: ../browser/menu.py:422
+msgid "title_translate_current_item"
+msgstr ""
+
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:277
+#: ../browser/menu.py:492
 msgid "title_translate_menu"
 msgstr ""
 
@@ -567,8 +557,8 @@ msgstr ""
 msgid "translation_to"
 msgstr ""
 
-#. Default: "Universal Link"
-#: ../browser/menu.py:211
+#. Default: "Universal link"
+#: ../browser/menu.py:235
 msgid "universal_link"
 msgstr ""
 

--- a/src/plone/app/multilingual/locales/rebuild.sh
+++ b/src/plone/app/multilingual/locales/rebuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PRODUCT=plone.app.multilingual
 

--- a/src/plone/app/multilingual/locales/sk/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/sk/LC_MESSAGES/plone.app.multilingual.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone.app.multilingual\n"
-"POT-Creation-Date: 2017-07-10 06:24+0000\n"
+"POT-Creation-Date: 2017-07-13 21:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Radek Jankiewicz <backup.rlacko@gmail.com>\n"
 "Language-Team: plone-cat <plone-cat@plone.org>\n"
@@ -167,13 +167,8 @@ msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:122
+#: ../browser/menu.py:161
 msgid "create_translation"
-msgstr ""
-
-#. Default: "Create ${lang_name} folder"
-#: ../browser/menu.py:118
-msgid "create_translation_folder"
 msgstr ""
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
@@ -181,13 +176,9 @@ msgstr ""
 msgid "description_after_migration_cleanup"
 msgstr ""
 
-#. Default: "Edit with the babel_edit"
-#: ../browser/menu.py:70
-msgid "description_babel_edit"
-msgstr "Upraviť pomocou editora 'Babel'"
-
-#. Default: "Babel edit ${lang_name}"
-#: ../browser/menu.py:139
+#. Default: "Edit {lang_name} with the two-column translation view"
+#: ../browser/menu.py:117
+#, fuzzy
 msgid "description_babeledit_menu"
 msgstr "Upraviť pomocou editora 'Babel': ${lang_name}"
 
@@ -212,7 +203,7 @@ msgid "description_google_translation_key"
 msgstr "API kľúč pre Google Translation servis"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:193
+#: ../browser/menu.py:466
 msgid "description_language_folder"
 msgstr "Choďte do zložky podľa nastavenia jazyka v prehliadači užívateľa"
 
@@ -233,7 +224,7 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:171
+#: ../browser/menu.py:219
 msgid "description_modify_translations"
 msgstr ""
 
@@ -257,13 +248,14 @@ msgstr ""
 msgid "description_selector_lookup_translations_policy"
 msgstr "Predvolený jazyk, v ktorom je vytvorený obsah, a užívateľské rozhranie."
 
-#. Default: "Set or change the current content language"
-#: ../browser/menu.py:255
+#. Default: "Move the translation under another language folder"
+#: ../browser/menu.py:140
+#, fuzzy
 msgid "description_set_language"
 msgstr "Nastavenie alebo zmena aktuálneho jazyka obsahu"
 
-#. Default: "Show the shared Language Independent Folder"
-#: ../browser/menu.py:236
+#. Default: "Open the language independent assets folder"
+#: ../browser/menu.py:445
 #, fuzzy
 msgid "description_shared_folder"
 msgstr "Zobraziť priečinok s obsahom v neutrálnom jazyku"
@@ -274,7 +266,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:102
+#: ../browser/menu.py:166
 msgid "description_translate_into"
 msgstr "Preložiť do ${lang_name}"
 
@@ -283,8 +275,9 @@ msgstr "Preložiť do ${lang_name}"
 msgid "description_translation_map"
 msgstr "Mapa prekladu."
 
-#. Default: "Universal Language content link"
-#: ../browser/menu.py:215
+#. Default: "Universal link to the content in user's preferred language"
+#: ../browser/menu.py:239
+#, fuzzy
 msgid "description_universal_link"
 msgstr "Odkaz na obsah v univerzálnom preklade"
 
@@ -294,13 +287,8 @@ msgid "description_update_language"
 msgstr "Nepreložené jazyky pre tento objekt"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:159
+#: ../browser/menu.py:112
 msgid "edit_translation"
-msgstr ""
-
-#. Default: "Edit ${lang_name} folder"
-#: ../browser/menu.py:155
-msgid "edit_translation_folder"
 msgstr ""
 
 #. Default: "Folder's id is not a valid language code"
@@ -446,7 +434,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:276
+#: ../browser/menu.py:491
 msgid "label_translate_menu"
 msgstr "Preložiť"
 
@@ -462,7 +450,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:189
+#: ../browser/menu.py:462
 msgid "language_folder"
 msgstr "Návrat do zložky jazyka"
 
@@ -521,8 +509,8 @@ msgstr ""
 msgid "relation_migration_with_not_needed"
 msgstr ""
 
-#. Default: "Go to Assets folder"
-#: ../browser/menu.py:232
+#. Default: "Open ${title} folder"
+#: ../browser/menu.py:440
 #, fuzzy
 msgid "shared_folder"
 msgstr "Choďte do zdieľanej zložky"
@@ -532,28 +520,34 @@ msgstr "Choďte do zdieľanej zložky"
 msgid "title_available_languages"
 msgstr "Dostupné jazyky"
 
-#. Default: "Edit with babel view"
-#: ../browser/menu.py:66
-msgid "title_babel_edit"
-msgstr "Upraviť pomocou editora Babel"
-
 #. Default: "Language"
 #: ../browser/interfaces.py:54
 msgid "title_language"
 msgstr "Jazyk"
 
-#. Default: "Modify translations..."
-#: ../browser/menu.py:167
+#. Default: "Manage translations"
+#: ../browser/menu.py:215
 msgid "title_modify_translations"
 msgstr ""
 
-#. Default: "Set content language"
-#: ../browser/menu.py:251
+#. Default: "Change content language"
+#: ../browser/menu.py:136
+#, fuzzy
 msgid "title_set_language"
 msgstr "Nastavenie jazyka obsahu"
 
+#. Default: "Folder translation"
+#: ../browser/menu.py:258
+msgid "title_translate_current_folder"
+msgstr ""
+
+#. Default: "Item translation"
+#: ../browser/menu.py:422
+msgid "title_translate_current_item"
+msgstr ""
+
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:277
+#: ../browser/menu.py:492
 msgid "title_translate_menu"
 msgstr "Správa prekladov vášho obsahu."
 
@@ -567,8 +561,9 @@ msgstr "Preklady:"
 msgid "translation_to"
 msgstr "Preklad do ${language}"
 
-#. Default: "Universal Link"
-#: ../browser/menu.py:211
+#. Default: "Universal link"
+#: ../browser/menu.py:235
+#, fuzzy
 msgid "universal_link"
 msgstr "Univerzálny odkaz"
 

--- a/src/plone/app/multilingual/locales/uk/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/uk/LC_MESSAGES/plone.app.multilingual.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone.app.multilingual\n"
-"POT-Creation-Date: 2017-07-10 06:24+0000\n"
+"POT-Creation-Date: 2017-07-13 21:35+0000\n"
 "PO-Revision-Date: 2013-02-08 00:35+0300\n"
 "Last-Translator: Roman Kozlovskyi <krzroman@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -169,27 +169,18 @@ msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:122
+#: ../browser/menu.py:161
 msgid "create_translation"
 msgstr "Створити ${lang_name}"
-
-#. Default: "Create ${lang_name} folder"
-#: ../browser/menu.py:118
-msgid "create_translation_folder"
-msgstr ""
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
 #: ../browser/templates/migration.pt:225
 msgid "description_after_migration_cleanup"
 msgstr "Цей крок виправить деякі втрачені залежності ITranslatable інтерфейсу приховані у каталогу зв'язків і позбавляється від них. Він може бути запущений тільки тоді, коли LinguaPlone вже видалений."
 
-#. Default: "Edit with the babel_edit"
-#: ../browser/menu.py:70
-msgid "description_babel_edit"
-msgstr "Редагувати з babel_edit"
-
-#. Default: "Babel edit ${lang_name}"
-#: ../browser/menu.py:139
+#. Default: "Edit {lang_name} with the two-column translation view"
+#: ../browser/menu.py:117
+#, fuzzy
 msgid "description_babeledit_menu"
 msgstr "Babel редагування ${lang_name}"
 
@@ -214,7 +205,7 @@ msgid "description_google_translation_key"
 msgstr "Чи є оплачено API для того, щоб використовувати Google перекладацькі послуги"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:193
+#: ../browser/menu.py:466
 msgid "description_language_folder"
 msgstr "Перейти в теку мови вибрану браузером користувача"
 
@@ -234,7 +225,7 @@ msgid "description_migration_results"
 msgstr "Тут ви побачите результати процесу міграції"
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:171
+#: ../browser/menu.py:219
 msgid "description_modify_translations"
 msgstr ""
 
@@ -258,13 +249,14 @@ msgstr "Цей крок перемість вмісту сайту у відпо
 msgid "description_selector_lookup_translations_policy"
 msgstr "Мова за замовчуванням використовується для контенту і користувальницького інтерфейсу цього сайту."
 
-#. Default: "Set or change the current content language"
-#: ../browser/menu.py:255
+#. Default: "Move the translation under another language folder"
+#: ../browser/menu.py:140
+#, fuzzy
 msgid "description_set_language"
 msgstr "Встановити або змінити мову даного контенту"
 
-#. Default: "Show the shared Language Independent Folder"
-#: ../browser/menu.py:236
+#. Default: "Open the language independent assets folder"
+#: ../browser/menu.py:445
 #, fuzzy
 msgid "description_shared_folder"
 msgstr "Показати мову загальної (нейтральної мови) теки"
@@ -275,7 +267,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr "Цей крок буде перетворювати зв'язки між переклади збережені LinguaPlone в каталозі PAM. Цей крок не є руйнівним і може виконатьсь стільки разів, скільки необхідно."
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:102
+#: ../browser/menu.py:166
 msgid "description_translate_into"
 msgstr "Перекласти на ${lang_name}"
 
@@ -284,8 +276,9 @@ msgstr "Перекласти на ${lang_name}"
 msgid "description_translation_map"
 msgstr "Карта перекладів."
 
-#. Default: "Universal Language content link"
-#: ../browser/menu.py:215
+#. Default: "Universal link to the content in user's preferred language"
+#: ../browser/menu.py:239
+#, fuzzy
 msgid "description_universal_link"
 msgstr "Універсальне мовне посилання на контент"
 
@@ -295,14 +288,9 @@ msgid "description_update_language"
 msgstr "Неперекладені мови з поточного контенту"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:159
+#: ../browser/menu.py:112
 msgid "edit_translation"
 msgstr "Редагувати ${lang_name}"
-
-#. Default: "Edit ${lang_name} folder"
-#: ../browser/menu.py:155
-msgid "edit_translation_folder"
-msgstr ""
 
 #. Default: "Folder's id is not a valid language code"
 #: ../browser/migrator.py:308
@@ -447,7 +435,7 @@ msgid "label_total_relations"
 msgstr "Кількість задіяних зв'язків:"
 
 #. Default: "Translate"
-#: ../browser/menu.py:276
+#: ../browser/menu.py:491
 msgid "label_translate_menu"
 msgstr "Перекласти"
 
@@ -463,7 +451,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:189
+#: ../browser/menu.py:462
 msgid "language_folder"
 msgstr "Повернутися в папку мови"
 
@@ -522,8 +510,8 @@ msgstr "Не можливо виконати цей крок, не видаля�
 msgid "relation_migration_with_not_needed"
 msgstr "Ваш сайт не має ніякого каталогу відношення, і тому цей крок міграції не вимагається"
 
-#. Default: "Go to Assets folder"
-#: ../browser/menu.py:232
+#. Default: "Open ${title} folder"
+#: ../browser/menu.py:440
 #, fuzzy
 msgid "shared_folder"
 msgstr "Перейти до спільної теки"
@@ -533,28 +521,34 @@ msgstr "Перейти до спільної теки"
 msgid "title_available_languages"
 msgstr "Доступні мови"
 
-#. Default: "Edit with babel view"
-#: ../browser/menu.py:66
-msgid "title_babel_edit"
-msgstr "Редагувати з babel виглядом"
-
 #. Default: "Language"
 #: ../browser/interfaces.py:54
 msgid "title_language"
 msgstr "Мова"
 
-#. Default: "Modify translations..."
-#: ../browser/menu.py:167
+#. Default: "Manage translations"
+#: ../browser/menu.py:215
 msgid "title_modify_translations"
 msgstr ""
 
-#. Default: "Set content language"
-#: ../browser/menu.py:251
+#. Default: "Change content language"
+#: ../browser/menu.py:136
+#, fuzzy
 msgid "title_set_language"
 msgstr "Встановити мову контенту"
 
+#. Default: "Folder translation"
+#: ../browser/menu.py:258
+msgid "title_translate_current_folder"
+msgstr ""
+
+#. Default: "Item translation"
+#: ../browser/menu.py:422
+msgid "title_translate_current_item"
+msgstr ""
+
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:277
+#: ../browser/menu.py:492
 msgid "title_translate_menu"
 msgstr "Управління перекладами вашого контенту."
 
@@ -568,8 +562,9 @@ msgstr "Переклади:"
 msgid "translation_to"
 msgstr "Переклад на ${language}"
 
-#. Default: "Universal Link"
-#: ../browser/menu.py:211
+#. Default: "Universal link"
+#: ../browser/menu.py:235
+#, fuzzy
 msgid "universal_link"
 msgstr "Універсальне посилання"
 

--- a/src/plone/app/multilingual/locales/zh_CN/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/zh_CN/LC_MESSAGES/plone.app.multilingual.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-07-10 06:24+0000\n"
+"POT-Creation-Date: 2017-07-13 21:35+0000\n"
 "PO-Revision-Date: 2012-03-24 23:31+0800\n"
 "Last-Translator: Jian Aijun <jianaijun@gmail.com>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
@@ -170,13 +170,8 @@ msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:122
+#: ../browser/menu.py:161
 msgid "create_translation"
-msgstr ""
-
-#. Default: "Create ${lang_name} folder"
-#: ../browser/menu.py:118
-msgid "create_translation_folder"
 msgstr ""
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
@@ -184,13 +179,8 @@ msgstr ""
 msgid "description_after_migration_cleanup"
 msgstr ""
 
-#. Default: "Edit with the babel_edit"
-#: ../browser/menu.py:70
-msgid "description_babel_edit"
-msgstr ""
-
-#. Default: "Babel edit ${lang_name}"
-#: ../browser/menu.py:139
+#. Default: "Edit {lang_name} with the two-column translation view"
+#: ../browser/menu.py:117
 msgid "description_babeledit_menu"
 msgstr ""
 
@@ -215,7 +205,7 @@ msgid "description_google_translation_key"
 msgstr ""
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:193
+#: ../browser/menu.py:466
 msgid "description_language_folder"
 msgstr ""
 
@@ -235,7 +225,7 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:171
+#: ../browser/menu.py:219
 msgid "description_modify_translations"
 msgstr ""
 
@@ -259,13 +249,13 @@ msgstr ""
 msgid "description_selector_lookup_translations_policy"
 msgstr ""
 
-#. Default: "Set or change the current content language"
-#: ../browser/menu.py:255
+#. Default: "Move the translation under another language folder"
+#: ../browser/menu.py:140
 msgid "description_set_language"
 msgstr ""
 
-#. Default: "Show the shared Language Independent Folder"
-#: ../browser/menu.py:236
+#. Default: "Open the language independent assets folder"
+#: ../browser/menu.py:445
 msgid "description_shared_folder"
 msgstr ""
 
@@ -275,7 +265,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:102
+#: ../browser/menu.py:166
 msgid "description_translate_into"
 msgstr "翻译成 ${lang_name}"
 
@@ -284,8 +274,8 @@ msgstr "翻译成 ${lang_name}"
 msgid "description_translation_map"
 msgstr ""
 
-#. Default: "Universal Language content link"
-#: ../browser/menu.py:215
+#. Default: "Universal link to the content in user's preferred language"
+#: ../browser/menu.py:239
 msgid "description_universal_link"
 msgstr ""
 
@@ -295,13 +285,8 @@ msgid "description_update_language"
 msgstr ""
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:159
+#: ../browser/menu.py:112
 msgid "edit_translation"
-msgstr ""
-
-#. Default: "Edit ${lang_name} folder"
-#: ../browser/menu.py:155
-msgid "edit_translation_folder"
 msgstr ""
 
 #. Default: "Folder's id is not a valid language code"
@@ -447,7 +432,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:276
+#: ../browser/menu.py:491
 #, fuzzy
 msgid "label_translate_menu"
 msgstr "翻译成..."
@@ -464,7 +449,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:189
+#: ../browser/menu.py:462
 msgid "language_folder"
 msgstr ""
 
@@ -523,8 +508,8 @@ msgstr ""
 msgid "relation_migration_with_not_needed"
 msgstr ""
 
-#. Default: "Go to Assets folder"
-#: ../browser/menu.py:232
+#. Default: "Open ${title} folder"
+#: ../browser/menu.py:440
 msgid "shared_folder"
 msgstr ""
 
@@ -533,28 +518,33 @@ msgstr ""
 msgid "title_available_languages"
 msgstr ""
 
-#. Default: "Edit with babel view"
-#: ../browser/menu.py:66
-msgid "title_babel_edit"
-msgstr ""
-
 #. Default: "Language"
 #: ../browser/interfaces.py:54
 msgid "title_language"
 msgstr "语言"
 
-#. Default: "Modify translations..."
-#: ../browser/menu.py:167
+#. Default: "Manage translations"
+#: ../browser/menu.py:215
 msgid "title_modify_translations"
 msgstr ""
 
-#. Default: "Set content language"
-#: ../browser/menu.py:251
+#. Default: "Change content language"
+#: ../browser/menu.py:136
 msgid "title_set_language"
 msgstr ""
 
+#. Default: "Folder translation"
+#: ../browser/menu.py:258
+msgid "title_translate_current_folder"
+msgstr ""
+
+#. Default: "Item translation"
+#: ../browser/menu.py:422
+msgid "title_translate_current_item"
+msgstr ""
+
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:277
+#: ../browser/menu.py:492
 msgid "title_translate_menu"
 msgstr "为您的内容管理翻译。"
 
@@ -568,8 +558,8 @@ msgstr ""
 msgid "translation_to"
 msgstr ""
 
-#. Default: "Universal Link"
-#: ../browser/menu.py:211
+#. Default: "Universal link"
+#: ../browser/menu.py:235
 msgid "universal_link"
 msgstr ""
 

--- a/src/plone/app/multilingual/locales/zh_TW/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/zh_TW/LC_MESSAGES/plone.app.multilingual.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone.app.multilingual\n"
-"POT-Creation-Date: 2017-07-10 06:24+0000\n"
+"POT-Creation-Date: 2017-07-13 21:35+0000\n"
 "PO-Revision-Date: 2015-11-27 14:20+0800\n"
 "Last-Translator: TsungWei Hu <marr.tw@gmail.com>\n"
 "Language-Team: Plone I18N <plone-i18n@lists.sourcegorge.net>\n"
@@ -167,27 +167,18 @@ msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:122
+#: ../browser/menu.py:161
 msgid "create_translation"
 msgstr "新增 ${lang_name}"
-
-#. Default: "Create ${lang_name} folder"
-#: ../browser/menu.py:118
-msgid "create_translation_folder"
-msgstr "新增 ${lang_name} 目錄"
 
 #. Default: "This step will fix some lost dependencies to the ITranslatable interface hidden in the relation catalog and it gets rid of them. It must be run only when LinguaPlone is already uninstalled."
 #: ../browser/templates/migration.pt:225
 msgid "description_after_migration_cleanup"
 msgstr ""
 
-#. Default: "Edit with the babel_edit"
-#: ../browser/menu.py:70
-msgid "description_babel_edit"
-msgstr "編輯翻譯"
-
-#. Default: "Babel edit ${lang_name}"
-#: ../browser/menu.py:139
+#. Default: "Edit {lang_name} with the two-column translation view"
+#: ../browser/menu.py:117
+#, fuzzy
 msgid "description_babeledit_menu"
 msgstr "編輯 ${lang_name}"
 
@@ -212,7 +203,7 @@ msgid "description_google_translation_key"
 msgstr ""
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:193
+#: ../browser/menu.py:466
 msgid "description_language_folder"
 msgstr "回到瀏覽器預設語系的目錄"
 
@@ -232,7 +223,7 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:171
+#: ../browser/menu.py:219
 msgid "description_modify_translations"
 msgstr ""
 
@@ -256,13 +247,14 @@ msgstr ""
 msgid "description_selector_lookup_translations_policy"
 msgstr ""
 
-#. Default: "Set or change the current content language"
-#: ../browser/menu.py:255
+#. Default: "Move the translation under another language folder"
+#: ../browser/menu.py:140
+#, fuzzy
 msgid "description_set_language"
 msgstr "設定目前的內容語系"
 
-#. Default: "Show the shared Language Independent Folder"
-#: ../browser/menu.py:236
+#. Default: "Open the language independent assets folder"
+#: ../browser/menu.py:445
 #, fuzzy
 msgid "description_shared_folder"
 msgstr "顯示語系共享的目錄"
@@ -273,7 +265,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:102
+#: ../browser/menu.py:166
 msgid "description_translate_into"
 msgstr "翻譯為 ${lang_name}"
 
@@ -282,8 +274,9 @@ msgstr "翻譯為 ${lang_name}"
 msgid "description_translation_map"
 msgstr ""
 
-#. Default: "Universal Language content link"
-#: ../browser/menu.py:215
+#. Default: "Universal link to the content in user's preferred language"
+#: ../browser/menu.py:239
+#, fuzzy
 msgid "description_universal_link"
 msgstr "Universal Language 網址"
 
@@ -293,14 +286,9 @@ msgid "description_update_language"
 msgstr "這個內容尚未翻譯的語系"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:159
+#: ../browser/menu.py:112
 msgid "edit_translation"
 msgstr "編輯 ${lang_name}"
-
-#. Default: "Edit ${lang_name} folder"
-#: ../browser/menu.py:155
-msgid "edit_translation_folder"
-msgstr "編輯 ${lang_name} 目錄"
 
 #. Default: "Folder's id is not a valid language code"
 #: ../browser/migrator.py:308
@@ -445,7 +433,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:276
+#: ../browser/menu.py:491
 msgid "label_translate_menu"
 msgstr "翻譯"
 
@@ -461,7 +449,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:189
+#: ../browser/menu.py:462
 msgid "language_folder"
 msgstr "回到語系目錄"
 
@@ -520,8 +508,8 @@ msgstr ""
 msgid "relation_migration_with_not_needed"
 msgstr "網站裡找不到 relation catalog 所以不需要執行昇級步驟。"
 
-#. Default: "Go to Assets folder"
-#: ../browser/menu.py:232
+#. Default: "Open ${title} folder"
+#: ../browser/menu.py:440
 #, fuzzy
 msgid "shared_folder"
 msgstr "回到共享目錄"
@@ -531,28 +519,34 @@ msgstr "回到共享目錄"
 msgid "title_available_languages"
 msgstr "可用的語系"
 
-#. Default: "Edit with babel view"
-#: ../browser/menu.py:66
-msgid "title_babel_edit"
-msgstr "透過 Babel View 編輯"
-
 #. Default: "Language"
 #: ../browser/interfaces.py:54
 msgid "title_language"
 msgstr "語系"
 
-#. Default: "Modify translations..."
-#: ../browser/menu.py:167
+#. Default: "Manage translations"
+#: ../browser/menu.py:215
 msgid "title_modify_translations"
 msgstr ""
 
-#. Default: "Set content language"
-#: ../browser/menu.py:251
+#. Default: "Change content language"
+#: ../browser/menu.py:136
+#, fuzzy
 msgid "title_set_language"
 msgstr "設定內容語系"
 
+#. Default: "Folder translation"
+#: ../browser/menu.py:258
+msgid "title_translate_current_folder"
+msgstr ""
+
+#. Default: "Item translation"
+#: ../browser/menu.py:422
+msgid "title_translate_current_item"
+msgstr ""
+
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:277
+#: ../browser/menu.py:492
 msgid "title_translate_menu"
 msgstr "管理項目的翻譯"
 
@@ -566,8 +560,9 @@ msgstr "翻譯:"
 msgid "translation_to"
 msgstr "翻譯成 ${language}"
 
-#. Default: "Universal Link"
-#: ../browser/menu.py:211
+#. Default: "Universal link"
+#: ../browser/menu.py:235
+#, fuzzy
 msgid "universal_link"
 msgstr "Universal Link"
 

--- a/src/plone/app/multilingual/tests/test_helper_views.py
+++ b/src/plone/app/multilingual/tests/test_helper_views.py
@@ -46,7 +46,7 @@ class PAMFuncTestHelperViews(unittest.TestCase):
         transaction.commit()
 
         self.browser.open(a_en.absolute_url())
-        self.browser.getLink("Universal Link").click()
+        self.browser.getLink("Universal link").click()
         self.assertEqual(self.browser.url, a_ca.absolute_url())
 
 

--- a/test-plone-5.x.cfg
+++ b/test-plone-5.x.cfg
@@ -108,6 +108,7 @@ deprecated-aliases = True
 [versions]
 setuptools = >=7.0
 zc.buildout = >=2.2.5
+coverage =
 
 # Unpin this product so we are testing development code
 plone.app.multilingual =


### PR DESCRIPTION
- When viewing a folder with a default page, the translation menu shows all
  options for both the folder and then the default page in the
  same order and with the same titles. The option to edit the current page in
  babel view have been merged with the options to edit the other translations
  to make the menu more consistent

- Translation menu show the title of the language independent folder on
  the language independent folder link in translation menu as
  "Open ${title} folder"

- Translation menu no longer includes "Set content language"-menuitem, which
  was redundant (but less transparent in its behavior) to just cutting and
  pasting a content under the desired language folder

Before:

![the collection english 1](https://user-images.githubusercontent.com/160447/27948819-e29938c4-6303-11e7-95c8-e3c200a05777.jpg)

After:

![the collection english](https://user-images.githubusercontent.com/160447/27948824-e62a7e4e-6303-11e7-9715-3d158b66c515.jpg)


