### PR TITLE
shortname for behavior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Set shortname ``plone.translatable`` to behavior ``plone.app.multilingual.dx.interfaces.IDexterityTranslatable``.
+  [jensens]
 
 Bug fixes:
 

--- a/src/plone/app/multilingual/dx/configure.zcml
+++ b/src/plone/app/multilingual/dx/configure.zcml
@@ -33,6 +33,7 @@
   <plone:behavior
       title="Multilingual Support"
       description="Make this content type multilingual aware"
+      name="plone.translatable"
       provides=".interfaces.IDexterityTranslatable"/>
 
   <adapter


### PR DESCRIPTION
Set shortname ``plone.translatable`` to behavior ``plone.app.multilingual.dx.interfaces.IDexterityTranslatable``.