### PR TITLE
Marked robot test as noncritical

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Marked 'Scenario: As an editor I can translate a document' as noncritical.
+  This is a 'robot' test that has been unstable for a long time.
+  [maurits]
+
 - Fix issue where rendering translation menu did write on get when translations
   were enabled on old site with existing content
   [datakurre]

--- a/src/plone/app/multilingual/tests/robot/test_translate_content.robot
+++ b/src/plone/app/multilingual/tests/robot/test_translate_content.robot
@@ -12,6 +12,7 @@ Test Teardown  Close all browsers
 *** Test Cases ***
 
 Scenario: As an editor I can translate a document
+    [Tags]  unstable
     Given a site owner
       and a document in English
      When I translate the document into Catalan
@@ -54,10 +55,12 @@ a document in English with Catalan translation
 
 I translate the document into Catalan
   Go to  ${PLONE_URL}/en/an-english-document/@@create_translation?language=ca
+  Capture page screenshot
   Input Text  form.widgets.IDublinCore.title  A Catalan Document
   Click Link  Dates  # workaround for of TinyMCE editor field problem
+  Capture page screenshot
   Click button  css=#form-buttons-save
-  
+
   # Wait until page contains  Element creat
   # (Catalan translations not currently available)
 

--- a/src/plone/app/multilingual/tests/test_robot.py
+++ b/src/plone/app/multilingual/tests/test_robot.py
@@ -16,6 +16,8 @@ def test_suite():
     suite = unittest.TestSuite()
     suite.level = ROBOT_TEST_LEVEL
     suite.addTests([
-        layered(robotsuite.RobotTestSuite('robot'), layer=PAM_ROBOT_TESTING),
+        layered(
+            robotsuite.RobotTestSuite('robot', noncritical=['unstable']),
+            layer=PAM_ROBOT_TESTING),
     ])
     return suite


### PR DESCRIPTION
The 'Scenario: As an editor I can translate a document' has been unstable for a long time. On Jenkins it sometimes fails and sometimes passes. Locally it always passes.

For example http://jenkins.plone.org/job/plone-5.2-python-2.7-robot/290/robot/
And http://jenkins.plone.org/job/plone-5.2-python-2.7-robot/290/robot/Robot/Robot/Test%20Translate%20Content/Scenario%3A%20As%20an%20editor%20I%20can%20translate%20a%20document/

This PR marks it as noncritical, so Jenkins does not mark it as a real failure.
It *should* be fixed, and this PR adds two extra screen shots so we may have a better chance of seeing what is wrong.