### PR TITLE
Removed Extensions/Install.py.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New features:
 
 Bug fixes:
 
+- Removed ``Extensions/Install.py``.  This was only there as wrapper for
+  applying our uninstall profile, but that wrapper is no longer needed.
+  [maurits]
+
 - Marked 'Scenario: As an editor I can translate a document' as noncritical.
   This is a 'robot' test that has been unstable for a long time.
   [maurits]
@@ -30,7 +34,7 @@ Bug fixes:
   when no translations were yet available for the content
   [datakurre]
 
-- Fix issue where rendering universal link failed when trnanslation information
+- Fix issue where rendering universal link failed when translation information
   was not yet available for the content
   [datakurre]
 

--- a/src/plone/app/multilingual/Extensions/install.py
+++ b/src/plone/app/multilingual/Extensions/install.py
@@ -1,9 +1,0 @@
-# -*- coding: utf-8 -*-
-"""Legacy install/uninstall-methods to guard from re-installing/uninstalling"""
-from Products.CMFCore.utils import getToolByName
-
-
-def uninstall(context, reinstall=False):
-    setup_tool = getToolByName(context, 'portal_setup')
-    setup_tool.runAllImportStepsFromProfile(
-        'profile-plone.app.multilingual:uninstall', purge_old=False)


### PR DESCRIPTION
This was only there as wrapper for applying our uninstall profile, but that wrapper is no longer needed.
I think around Plone 4.3.9 this was added to CMFQuickInstaller,
and since Plone 5.1 the CMFQuickInstaller is not even really used anymore.