### PR TITLE
Fix add translation viewlet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix i18n markup of the viewlet shown in the translation creation view.
+  [erral] 
 
 
 5.1.4 (2018-02-02)

--- a/src/plone/app/multilingual/browser/templates/add-form-is-translation.pt
+++ b/src/plone/app/multilingual/browser/templates/add-form-is-translation.pt
@@ -5,10 +5,10 @@
   </strong>
   <tal:block i18n:domain="plone.app.multilingual"
       i18n:translate="add-form-is-translation">
-    This object is going to be a translation to <span i18n:name="language" tal:replace="view/language"></span> from:
+    This object is going to be a translation to <span i18n:name="language" tal:replace="python:view.language_name(view.language())"></span> from:
   </tal:block>
     <ul>
-        <li tal:repeat="origin view/origin"><span tal:content="origin/Language"></span>: <a href="#" class="link-overlay" tal:attributes="href origin/getURL">  <span tal:content="origin/Title"></span></a></li>
+        <li tal:repeat="origin view/origin"><span tal:content="python:view.language_name(origin.Language)"></span>: <a href="#" class="link-overlay" tal:attributes="href origin/getURL">  <span tal:content="origin/Title"></span></a></li>
     </ul>
     <span i18n:domain="plone.app.multilingual" i18n:translate="create-object-without-translation">
     If you want to create this object without being a translation press

--- a/src/plone/app/multilingual/browser/templates/add-form-is-translation.pt
+++ b/src/plone/app/multilingual/browser/templates/add-form-is-translation.pt
@@ -5,14 +5,14 @@
   </strong>
   <tal:block i18n:domain="plone.app.multilingual"
       i18n:translate="add-form-is-translation">
-    This object is going to be a translation to <span tal:replace="view/language"></span> from: 
+    This object is going to be a translation to <span i18n:name="language" tal:replace="view/language"></span> from:
+  </tal:block>
     <ul>
-        <li tal:repeat="origin view/origin"><a href="#" class="link-overlay" tal:attributes="href origin/getURL"> <span tal:content="origin/language"></span> <span tal:content="origin/Title"></span></a></li>
+        <li tal:repeat="origin view/origin"><span tal:content="origin/Language"></span>: <a href="#" class="link-overlay" tal:attributes="href origin/getURL">  <span tal:content="origin/Title"></span></a></li>
     </ul>
     <span i18n:domain="plone.app.multilingual" i18n:translate="create-object-without-translation">
     If you want to create this object without being a translation press
-    <a href="#" class="link-overlay" tal:attributes="href view/returnURL">here</a>
+    <a href="#" class="link-overlay" i18n:name="url" tal:attributes="href view/returnURL" i18n:translate="">here</a>
     </span>
-  </tal:block>
 </div>
 </div>

--- a/src/plone/app/multilingual/browser/viewlets.py
+++ b/src/plone/app/multilingual/browser/viewlets.py
@@ -45,8 +45,20 @@ class AddFormIsATranslationViewlet(ViewletBase):
     def language(self):
         return self.lang
 
-    def origin(self):
-        return self.origin
+    def languages(self):
+        """Returns list of languages."""
+        self.tool = getToolByName(self.context, 'portal_languages', None)
+        if self.tool is None:
+            return []
+
+        languages = {lang: info for (lang, info) in
+                        self.tool.getAvailableLanguageInformation().items()
+                        if info["selected"]}
+
+        return languages
+
+    def language_name(self, lang_code):
+        return self.languages().get(lang_code).get('native')
 
     def render(self):
         if self.available:

--- a/src/plone/app/multilingual/browser/viewlets.py
+++ b/src/plone/app/multilingual/browser/viewlets.py
@@ -109,7 +109,7 @@ class AddFormIsATranslationViewlet(ViewletBase):
         else:
             self.lang = 'NaN'
         catalog = getToolByName(self.context, 'portal_catalog')
-        query = {'TranslationGroup': tg, 'Language': 'all'}
+        query = {'TranslationGroup': tg}
         self.origin = catalog.searchResults(query)
 
 

--- a/src/plone/app/multilingual/locales/ca/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/ca/LC_MESSAGES/plone.app.multilingual.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.2b3\n"
-"POT-Creation-Date: 2017-07-13 21:35+0000\n"
+"POT-Creation-Date: 2018-03-19 06:49+0000\n"
 "PO-Revision-Date: 2012-03-23 16:45 +0000\n"
 "Last-Translator: ramon.nb@gmail.com>\n"
 "Language-Team: plone-cat <plone-cat@plone.org>\n"
@@ -15,15 +15,15 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: plone.app.multilingual\n"
 
-#: ../browser/migrator.py:85
+#: ../browser/migrator.py:86
 msgid "After migration relation cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:60
 msgid "Cancel"
 msgstr ""
 
-#: ../browser/controlpanel.py:65
+#: ../browser/controlpanel.py:63
 msgid "Changes canceled."
 msgstr ""
 
@@ -32,7 +32,7 @@ msgstr ""
 msgid "Cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:49
+#: ../browser/controlpanel.py:47
 msgid "Default language not in available languages"
 msgstr ""
 
@@ -44,7 +44,7 @@ msgstr ""
 msgid "Install to enable multilingual content support with plone.app.multilingual"
 msgstr ""
 
-#: ../browser/translate.py:69
+#: ../browser/translate.py:70
 msgid "Invalid field"
 msgstr ""
 
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Language control panel"
 msgstr ""
 
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Make this content type multilingual aware"
 msgstr ""
 
@@ -61,16 +61,16 @@ msgid "Move"
 msgstr ""
 
 #. Default: "Multilingual"
-#: ../interfaces.py:183
+#: ../interfaces.py:184
 msgid "Multilingual"
 msgstr ""
 
-#: ../browser/controlpanel.py:32
+#: ../browser/controlpanel.py:30
 msgid "Multilingual Settings"
 msgstr "Configuració Multilingual"
 
 #: ../configure.zcml:151
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Multilingual Support"
 msgstr ""
 
@@ -78,11 +78,11 @@ msgstr ""
 msgid "Multilingual Support [uninstall]"
 msgstr ""
 
-#: ../browser/translate.py:54
+#: ../browser/translate.py:55
 msgid "Need a field"
 msgstr ""
 
-#: ../browser/controlpanel.py:174
+#: ../browser/controlpanel.py:172
 msgid "Not translated"
 msgstr ""
 
@@ -94,19 +94,19 @@ msgstr ""
 msgid "Relocate"
 msgstr ""
 
-#: ../browser/migrator.py:127
+#: ../browser/migrator.py:128
 msgid "Relocate content to the proper root language folder"
 msgstr ""
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:36
 msgid "Save"
 msgstr ""
 
-#: ../interfaces.py:169
+#: ../interfaces.py:170
 msgid "Search for closest translation in parent's content chain."
 msgstr ""
 
-#: ../interfaces.py:172
+#: ../interfaces.py:173
 msgid "Show user dialog with information about the available translations."
 msgstr ""
 
@@ -126,7 +126,7 @@ msgstr ""
 msgid "Transfer"
 msgstr ""
 
-#: ../browser/migrator.py:50
+#: ../browser/migrator.py:51
 msgid "Transfer multilingual catalog information"
 msgstr ""
 
@@ -138,23 +138,23 @@ msgstr ""
 msgid "Update bundle regristration"
 msgstr ""
 
-#. Default: "This object is going to be a translation to ${DYNAMIC_CONTENT} from: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "This object is going to be a translation to ${language} from:"
+#: ../browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
 msgstr ""
 
 #. Default: "assets"
-#: ../browser/setup.py:139
+#: ../browser/setup.py:140
 msgid "assets_folder_id"
 msgstr ""
 
 #. Default: "Assets"
-#: ../browser/setup.py:142
+#: ../browser/setup.py:143
 msgid "assets_folder_title"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:44
+#: ../browser/modify.py:46
 msgid "connect_translation"
 msgstr ""
 
@@ -162,13 +162,13 @@ msgstr ""
 msgid "content"
 msgstr "Contingut"
 
-#. Default: "If you want to create this object without being a translation press <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">here</a>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "If you want to create this object without being a translation press ${url}"
+#: ../browser/templates/add-form-is-translation.pt:15
 msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:161
+#: ../browser/menu.py:162
 msgid "create_translation"
 msgstr ""
 
@@ -178,32 +178,32 @@ msgid "description_after_migration_cleanup"
 msgstr ""
 
 #. Default: "Edit {lang_name} with the two-column translation view"
-#: ../browser/menu.py:117
+#: ../browser/menu.py:118
 msgid "description_babeledit_menu"
 msgstr ""
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
-#: ../interfaces.py:240
+#: ../interfaces.py:241
 msgid "description_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
-#: ../interfaces.py:221
+#: ../interfaces.py:222
 msgid "description_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter using language the content on folder_contents"
-#: ../interfaces.py:198
+#: ../interfaces.py:199
 msgid "description_filter_content"
 msgstr ""
 
 #. Default: "Is a paying API in order to use google translation service"
-#: ../interfaces.py:256
+#: ../interfaces.py:257
 msgid "description_google_translation_key"
 msgstr ""
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:466
+#: ../browser/menu.py:469
 msgid "description_language_folder"
 msgstr ""
 
@@ -223,12 +223,12 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:219
+#: ../browser/menu.py:220
 msgid "description_modify_translations"
 msgstr ""
 
 #. Default: "After creating a new translation redirecto to babel view"
-#: ../interfaces.py:209
+#: ../interfaces.py:210
 msgid "description_redirect_babel_view"
 msgstr ""
 
@@ -243,17 +243,17 @@ msgid "description_relocate_content"
 msgstr ""
 
 #. Default: "The default language used for the content and the UI of this site."
-#: ../interfaces.py:268
+#: ../interfaces.py:269
 msgid "description_selector_lookup_translations_policy"
 msgstr ""
 
 #. Default: "Move the translation under another language folder"
-#: ../browser/menu.py:140
+#: ../browser/menu.py:141
 msgid "description_set_language"
 msgstr ""
 
 #. Default: "Open the language independent assets folder"
-#: ../browser/menu.py:445
+#: ../browser/menu.py:448
 msgid "description_shared_folder"
 msgstr ""
 
@@ -263,7 +263,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:166
+#: ../browser/menu.py:167
 msgid "description_translate_into"
 msgstr ""
 
@@ -273,7 +273,7 @@ msgid "description_translation_map"
 msgstr ""
 
 #. Default: "Universal link to the content in user's preferred language"
-#: ../browser/menu.py:239
+#: ../browser/menu.py:241
 msgid "description_universal_link"
 msgstr ""
 
@@ -283,22 +283,22 @@ msgid "description_update_language"
 msgstr ""
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:112
+#: ../browser/menu.py:113
 msgid "edit_translation"
 msgstr ""
 
 #. Default: "Folder's id is not a valid language code"
-#: ../browser/migrator.py:308
+#: ../browser/migrator.py:309
 msgid "folder_to_lrf_id_not_language"
 msgstr ""
 
 #. Default: "Only folders just below the root can be transformed"
-#: ../browser/migrator.py:297
+#: ../browser/migrator.py:298
 msgid "folder_to_lrf_not_next_to_root"
 msgstr ""
 
 #. Default: "Folder has been successfully transformed to a language root folder"
-#: ../browser/migrator.py:331
+#: ../browser/migrator.py:332
 msgid "folder_to_lrf_success"
 msgstr ""
 
@@ -308,22 +308,22 @@ msgid "heading_available_translations"
 msgstr ""
 
 #. Default: "Use buttons in the bable view for up to how many translations?"
-#: ../interfaces.py:236
+#: ../interfaces.py:237
 msgid "heading_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "Bypass language independent field permission check"
-#: ../interfaces.py:218
+#: ../interfaces.py:219
 msgid "heading_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter content by language."
-#: ../interfaces.py:195
+#: ../interfaces.py:196
 msgid "heading_filter_content"
 msgstr ""
 
 #. Default: "Google Translation API Key"
-#: ../interfaces.py:253
+#: ../interfaces.py:254
 msgid "heading_google_translation_key"
 msgstr ""
 
@@ -348,12 +348,12 @@ msgid "heading_not_available_in_language"
 msgstr ""
 
 #. Default: "Redirect on creation to babel view."
-#: ../interfaces.py:206
+#: ../interfaces.py:207
 msgid "heading_redirect_babel_view"
 msgstr ""
 
 #. Default: "The policy used to determine how the lookup for available translations will be made by the language selector."
-#: ../interfaces.py:264
+#: ../interfaces.py:265
 msgid "heading_selector_lookup_translations_policy"
 msgstr ""
 
@@ -365,6 +365,10 @@ msgstr ""
 #. Default: "The migration of LinguaPlone content depends on an up-to-date Language index. Use this step to refresh this index. Warning: Depending on the number of items in your site, this can take a considerable amount of time."
 #: ../browser/templates/migration.pt:118
 msgid "help_reindex_language_index"
+msgstr ""
+
+#: ../browser/templates/add-form-is-translation.pt:15
+msgid "here"
 msgstr ""
 
 #. Default: "All translations"
@@ -388,7 +392,7 @@ msgid "label_cleanup"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:37
+#: ../browser/modify.py:39
 msgid "label_connect_translation"
 msgstr ""
 
@@ -430,7 +434,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:491
+#: ../browser/menu.py:494
 msgid "label_translate_menu"
 msgstr "Tradueix"
 
@@ -446,7 +450,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:462
+#: ../browser/menu.py:465
 msgid "language_folder"
 msgstr ""
 
@@ -471,7 +475,7 @@ msgid "legend_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "This form allows you to connect a currently existing translations of the current object."
-#: ../browser/modify.py:38
+#: ../browser/modify.py:40
 msgid "long_description_connect_translation"
 msgstr ""
 
@@ -491,7 +495,7 @@ msgid "not_configured_for_multiple_languages"
 msgstr ""
 
 #. Default: "All the configuration of a multilingual Plone site"
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid "pam_controlpanel_description"
 msgstr ""
 
@@ -506,7 +510,7 @@ msgid "relation_migration_with_not_needed"
 msgstr ""
 
 #. Default: "Open ${title} folder"
-#: ../browser/menu.py:440
+#: ../browser/menu.py:443
 #, fuzzy
 msgid "shared_folder"
 msgstr "Anar a Carpeta compartida"
@@ -522,28 +526,28 @@ msgid "title_language"
 msgstr "Llenguatge"
 
 #. Default: "Manage translations"
-#: ../browser/menu.py:215
+#: ../browser/menu.py:216
 msgid "title_modify_translations"
 msgstr ""
 
 #. Default: "Change content language"
-#: ../browser/menu.py:136
+#: ../browser/menu.py:137
 #, fuzzy
 msgid "title_set_language"
 msgstr "Establir Idioma del contingut"
 
 #. Default: "Folder translation"
-#: ../browser/menu.py:258
+#: ../browser/menu.py:260
 msgid "title_translate_current_folder"
 msgstr ""
 
 #. Default: "Item translation"
-#: ../browser/menu.py:422
+#: ../browser/menu.py:425
 msgid "title_translate_current_item"
 msgstr ""
 
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:492
+#: ../browser/menu.py:495
 msgid "title_translate_menu"
 msgstr "Administra les traduccions del teu contingut"
 
@@ -558,7 +562,7 @@ msgid "translation_to"
 msgstr ""
 
 #. Default: "Universal link"
-#: ../browser/menu.py:235
+#: ../browser/menu.py:237
 #, fuzzy
 msgid "universal_link"
 msgstr "Link universal"

--- a/src/plone/app/multilingual/locales/de/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/de/LC_MESSAGES/plone.app.multilingual.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone.app.multilingual\n"
-"POT-Creation-Date: 2017-07-13 21:35+0000\n"
+"POT-Creation-Date: 2018-03-19 06:49+0000\n"
 "PO-Revision-Date: 2013-06-05 11:55+0100\n"
 "Last-Translator: CMS HU Berlin <plone@cms.hu-berlin.de>\n"
 "Language-Team: CMS HU Berlin <plone@cms.hu-berlin.de>\n"
@@ -15,15 +15,15 @@ msgstr ""
 "Domain: plone.app.multilingual\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: ../browser/migrator.py:85
+#: ../browser/migrator.py:86
 msgid "After migration relation cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:60
 msgid "Cancel"
 msgstr ""
 
-#: ../browser/controlpanel.py:65
+#: ../browser/controlpanel.py:63
 msgid "Changes canceled."
 msgstr ""
 
@@ -32,7 +32,7 @@ msgstr ""
 msgid "Cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:49
+#: ../browser/controlpanel.py:47
 msgid "Default language not in available languages"
 msgstr ""
 
@@ -44,7 +44,7 @@ msgstr ""
 msgid "Install to enable multilingual content support with plone.app.multilingual"
 msgstr ""
 
-#: ../browser/translate.py:69
+#: ../browser/translate.py:70
 msgid "Invalid field"
 msgstr ""
 
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Language control panel"
 msgstr ""
 
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Make this content type multilingual aware"
 msgstr ""
 
@@ -61,16 +61,16 @@ msgid "Move"
 msgstr ""
 
 #. Default: "Multilingual"
-#: ../interfaces.py:183
+#: ../interfaces.py:184
 msgid "Multilingual"
 msgstr ""
 
-#: ../browser/controlpanel.py:32
+#: ../browser/controlpanel.py:30
 msgid "Multilingual Settings"
 msgstr ""
 
 #: ../configure.zcml:151
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Multilingual Support"
 msgstr ""
 
@@ -78,11 +78,11 @@ msgstr ""
 msgid "Multilingual Support [uninstall]"
 msgstr ""
 
-#: ../browser/translate.py:54
+#: ../browser/translate.py:55
 msgid "Need a field"
 msgstr ""
 
-#: ../browser/controlpanel.py:174
+#: ../browser/controlpanel.py:172
 msgid "Not translated"
 msgstr ""
 
@@ -94,19 +94,19 @@ msgstr ""
 msgid "Relocate"
 msgstr ""
 
-#: ../browser/migrator.py:127
+#: ../browser/migrator.py:128
 msgid "Relocate content to the proper root language folder"
 msgstr ""
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:36
 msgid "Save"
 msgstr ""
 
-#: ../interfaces.py:169
+#: ../interfaces.py:170
 msgid "Search for closest translation in parent's content chain."
 msgstr ""
 
-#: ../interfaces.py:172
+#: ../interfaces.py:173
 msgid "Show user dialog with information about the available translations."
 msgstr ""
 
@@ -126,7 +126,7 @@ msgstr ""
 msgid "Transfer"
 msgstr ""
 
-#: ../browser/migrator.py:50
+#: ../browser/migrator.py:51
 msgid "Transfer multilingual catalog information"
 msgstr ""
 
@@ -138,23 +138,23 @@ msgstr ""
 msgid "Update bundle regristration"
 msgstr ""
 
-#. Default: "This object is going to be a translation to ${DYNAMIC_CONTENT} from: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "This object is going to be a translation to ${language} from:"
+#: ../browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
 msgstr ""
 
 #. Default: "assets"
-#: ../browser/setup.py:139
+#: ../browser/setup.py:140
 msgid "assets_folder_id"
 msgstr ""
 
 #. Default: "Assets"
-#: ../browser/setup.py:142
+#: ../browser/setup.py:143
 msgid "assets_folder_title"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:44
+#: ../browser/modify.py:46
 msgid "connect_translation"
 msgstr ""
 
@@ -162,13 +162,13 @@ msgstr ""
 msgid "content"
 msgstr "Inhalt"
 
-#. Default: "If you want to create this object without being a translation press <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">here</a>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "If you want to create this object without being a translation press ${url}"
+#: ../browser/templates/add-form-is-translation.pt:15
 msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:161
+#: ../browser/menu.py:162
 msgid "create_translation"
 msgstr "${lang_name}"
 
@@ -178,32 +178,32 @@ msgid "description_after_migration_cleanup"
 msgstr ""
 
 #. Default: "Edit {lang_name} with the two-column translation view"
-#: ../browser/menu.py:117
+#: ../browser/menu.py:118
 msgid "description_babeledit_menu"
 msgstr "Editieren"
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
-#: ../interfaces.py:240
+#: ../interfaces.py:241
 msgid "description_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
-#: ../interfaces.py:221
+#: ../interfaces.py:222
 msgid "description_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter using language the content on folder_contents"
-#: ../interfaces.py:198
+#: ../interfaces.py:199
 msgid "description_filter_content"
 msgstr ""
 
 #. Default: "Is a paying API in order to use google translation service"
-#: ../interfaces.py:256
+#: ../interfaces.py:257
 msgid "description_google_translation_key"
 msgstr ""
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:466
+#: ../browser/menu.py:469
 msgid "description_language_folder"
 msgstr ""
 
@@ -223,12 +223,12 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:219
+#: ../browser/menu.py:220
 msgid "description_modify_translations"
 msgstr ""
 
 #. Default: "After creating a new translation redirecto to babel view"
-#: ../interfaces.py:209
+#: ../interfaces.py:210
 msgid "description_redirect_babel_view"
 msgstr ""
 
@@ -243,18 +243,18 @@ msgid "description_relocate_content"
 msgstr ""
 
 #. Default: "The default language used for the content and the UI of this site."
-#: ../interfaces.py:268
+#: ../interfaces.py:269
 msgid "description_selector_lookup_translations_policy"
 msgstr ""
 
 #. Default: "Move the translation under another language folder"
-#: ../browser/menu.py:140
+#: ../browser/menu.py:141
 #, fuzzy
 msgid "description_set_language"
 msgstr "Sprache setzen oder ändern."
 
 #. Default: "Open the language independent assets folder"
-#: ../browser/menu.py:445
+#: ../browser/menu.py:448
 msgid "description_shared_folder"
 msgstr ""
 
@@ -264,7 +264,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:166
+#: ../browser/menu.py:167
 msgid "description_translate_into"
 msgstr "Übersetzen in ${lang_name}"
 
@@ -274,7 +274,7 @@ msgid "description_translation_map"
 msgstr ""
 
 #. Default: "Universal link to the content in user's preferred language"
-#: ../browser/menu.py:239
+#: ../browser/menu.py:241
 msgid "description_universal_link"
 msgstr ""
 
@@ -284,22 +284,22 @@ msgid "description_update_language"
 msgstr "Sprachen, in die der Inhalt noch nicht übersetzt wurde."
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:112
+#: ../browser/menu.py:113
 msgid "edit_translation"
 msgstr "${lang_name} editieren"
 
 #. Default: "Folder's id is not a valid language code"
-#: ../browser/migrator.py:308
+#: ../browser/migrator.py:309
 msgid "folder_to_lrf_id_not_language"
 msgstr ""
 
 #. Default: "Only folders just below the root can be transformed"
-#: ../browser/migrator.py:297
+#: ../browser/migrator.py:298
 msgid "folder_to_lrf_not_next_to_root"
 msgstr ""
 
 #. Default: "Folder has been successfully transformed to a language root folder"
-#: ../browser/migrator.py:331
+#: ../browser/migrator.py:332
 msgid "folder_to_lrf_success"
 msgstr ""
 
@@ -309,22 +309,22 @@ msgid "heading_available_translations"
 msgstr ""
 
 #. Default: "Use buttons in the bable view for up to how many translations?"
-#: ../interfaces.py:236
+#: ../interfaces.py:237
 msgid "heading_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "Bypass language independent field permission check"
-#: ../interfaces.py:218
+#: ../interfaces.py:219
 msgid "heading_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter content by language."
-#: ../interfaces.py:195
+#: ../interfaces.py:196
 msgid "heading_filter_content"
 msgstr ""
 
 #. Default: "Google Translation API Key"
-#: ../interfaces.py:253
+#: ../interfaces.py:254
 msgid "heading_google_translation_key"
 msgstr ""
 
@@ -349,12 +349,12 @@ msgid "heading_not_available_in_language"
 msgstr ""
 
 #. Default: "Redirect on creation to babel view."
-#: ../interfaces.py:206
+#: ../interfaces.py:207
 msgid "heading_redirect_babel_view"
 msgstr ""
 
 #. Default: "The policy used to determine how the lookup for available translations will be made by the language selector."
-#: ../interfaces.py:264
+#: ../interfaces.py:265
 msgid "heading_selector_lookup_translations_policy"
 msgstr ""
 
@@ -366,6 +366,10 @@ msgstr ""
 #. Default: "The migration of LinguaPlone content depends on an up-to-date Language index. Use this step to refresh this index. Warning: Depending on the number of items in your site, this can take a considerable amount of time."
 #: ../browser/templates/migration.pt:118
 msgid "help_reindex_language_index"
+msgstr ""
+
+#: ../browser/templates/add-form-is-translation.pt:15
+msgid "here"
 msgstr ""
 
 #. Default: "All translations"
@@ -389,7 +393,7 @@ msgid "label_cleanup"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:37
+#: ../browser/modify.py:39
 msgid "label_connect_translation"
 msgstr ""
 
@@ -431,7 +435,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:491
+#: ../browser/menu.py:494
 msgid "label_translate_menu"
 msgstr "Übersetzen..."
 
@@ -447,7 +451,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:462
+#: ../browser/menu.py:465
 msgid "language_folder"
 msgstr ""
 
@@ -472,7 +476,7 @@ msgid "legend_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "This form allows you to connect a currently existing translations of the current object."
-#: ../browser/modify.py:38
+#: ../browser/modify.py:40
 msgid "long_description_connect_translation"
 msgstr ""
 
@@ -492,7 +496,7 @@ msgid "not_configured_for_multiple_languages"
 msgstr ""
 
 #. Default: "All the configuration of a multilingual Plone site"
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid "pam_controlpanel_description"
 msgstr ""
 
@@ -507,7 +511,7 @@ msgid "relation_migration_with_not_needed"
 msgstr ""
 
 #. Default: "Open ${title} folder"
-#: ../browser/menu.py:440
+#: ../browser/menu.py:443
 msgid "shared_folder"
 msgstr "${title} Ordner öffnen"
 
@@ -522,29 +526,29 @@ msgid "title_language"
 msgstr "Sprache"
 
 #. Default: "Manage translations"
-#: ../browser/menu.py:215
+#: ../browser/menu.py:216
 #, fuzzy
 msgid "title_modify_translations"
 msgstr "Übersetzungen verwalten"
 
 #. Default: "Change content language"
-#: ../browser/menu.py:136
+#: ../browser/menu.py:137
 #, fuzzy
 msgid "title_set_language"
 msgstr "Sprache setzen"
 
 #. Default: "Folder translation"
-#: ../browser/menu.py:258
+#: ../browser/menu.py:260
 msgid "title_translate_current_folder"
 msgstr ""
 
 #. Default: "Item translation"
-#: ../browser/menu.py:422
+#: ../browser/menu.py:425
 msgid "title_translate_current_item"
 msgstr ""
 
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:492
+#: ../browser/menu.py:495
 msgid "title_translate_menu"
 msgstr "Übersetzungen verwalten"
 
@@ -559,7 +563,7 @@ msgid "translation_to"
 msgstr "Übersetzen in ${language}"
 
 #. Default: "Universal link"
-#: ../browser/menu.py:235
+#: ../browser/menu.py:237
 msgid "universal_link"
 msgstr ""
 

--- a/src/plone/app/multilingual/locales/es/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/es/LC_MESSAGES/plone.app.multilingual.po
@@ -2,8 +2,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.2b3\n"
-"POT-Creation-Date: 2017-07-13 21:35+0000\n"
-"PO-Revision-Date: 2017-08-04 13:46+0200\n"
+"POT-Creation-Date: 2018-03-19 06:49+0000\n"
+"PO-Revision-Date: 2018-03-19 07:52+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: plone-cat <plone-cat@plone.org>\n"
 "MIME-Version: 1.0\n"
@@ -17,15 +17,15 @@ msgstr ""
 "Language: es\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: ../browser/migrator.py:85
+#: ../browser/migrator.py:86
 msgid "After migration relation cleanup"
 msgstr "Limpieza a realizar tras la migración"
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:60
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../browser/controlpanel.py:65
+#: ../browser/controlpanel.py:63
 msgid "Changes canceled."
 msgstr "Cambios cancelados."
 
@@ -33,7 +33,7 @@ msgstr "Cambios cancelados."
 msgid "Cleanup"
 msgstr "Limpieza"
 
-#: ../browser/controlpanel.py:49
+#: ../browser/controlpanel.py:47
 msgid "Default language not in available languages"
 msgstr "El idioma por defecto no está entre los idiomas disponibles"
 
@@ -45,7 +45,7 @@ msgstr "Sin embargo, esta es la lista de los idiomas para los que ya hay traducc
 msgid "Install to enable multilingual content support with plone.app.multilingual"
 msgstr "Instalar para activar el soporte de contenido multilingüe con plone.app.multilingual"
 
-#: ../browser/translate.py:69
+#: ../browser/translate.py:70
 msgid "Invalid field"
 msgstr "Campo no válido"
 
@@ -53,7 +53,7 @@ msgstr "Campo no válido"
 msgid "Language control panel"
 msgstr "Panel de Control de Idioma"
 
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Make this content type multilingual aware"
 msgstr "Hacer este tipo de contenido traducible"
 
@@ -62,15 +62,15 @@ msgid "Move"
 msgstr "Mover"
 
 #. Default: "Multilingual"
-#: ../interfaces.py:183
+#: ../interfaces.py:184
 msgid "Multilingual"
 msgstr "Multilingual"
 
-#: ../browser/controlpanel.py:32
+#: ../browser/controlpanel.py:30
 msgid "Multilingual Settings"
 msgstr "Configuración Multiidioma"
 
-#: ../configure.zcml:151 ../dx/configure.zcml:36
+#: ../configure.zcml:151 ../dx/configure.zcml:37
 msgid "Multilingual Support"
 msgstr "Soporte Multiidioma"
 
@@ -78,11 +78,11 @@ msgstr "Soporte Multiidioma"
 msgid "Multilingual Support [uninstall]"
 msgstr "Soporte Multiidioma [desinstalar]"
 
-#: ../browser/translate.py:54
+#: ../browser/translate.py:55
 msgid "Need a field"
 msgstr "Se necesita un campo"
 
-#: ../browser/controlpanel.py:174
+#: ../browser/controlpanel.py:172
 msgid "Not translated"
 msgstr "No traducidos"
 
@@ -94,19 +94,19 @@ msgstr "Refrescar"
 msgid "Relocate"
 msgstr "Recolocar"
 
-#: ../browser/migrator.py:127
+#: ../browser/migrator.py:128
 msgid "Relocate content to the proper root language folder"
 msgstr "Recolocar el contenido en el idioma adecuado"
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:36
 msgid "Save"
 msgstr "Guardar"
 
-#: ../interfaces.py:169
+#: ../interfaces.py:170
 msgid "Search for closest translation in parent's content chain."
 msgstr "Buscar la traducción más cercana entre los ancestros."
 
-#: ../interfaces.py:172
+#: ../interfaces.py:173
 msgid "Show user dialog with information about the available translations."
 msgstr "Mostrar una pantalla con información sobre las traducciones disponibles."
 
@@ -126,7 +126,7 @@ msgstr "Este elemento no tiene traducciones. Puede volver al sitio web:"
 msgid "Transfer"
 msgstr "Transferir"
 
-#: ../browser/migrator.py:50
+#: ../browser/migrator.py:51
 msgid "Transfer multilingual catalog information"
 msgstr "Transferir información del catálogo multiidioma"
 
@@ -138,28 +138,23 @@ msgstr "Desinstalar, elimina el soporte de contenido multiidioma de plone.app.mu
 msgid "Update bundle regristration"
 msgstr "Actualizar el registro "
 
-#. Default: "This object is going to be a translation to ${DYNAMIC_CONTENT} from: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "This object is going to be a translation to ${language} from:"
+#: ../browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
-msgstr ""
-"Este elemento va a ser una traducción al $\n"
-"{DYNAMIC_CONTENT} de:  <ul> <li><a href=\\\"$\n"
-"{DYNAMIC_CONTENT}\\\" class=\\\"link-overlay\\\"> <span>$\n"
-"{DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</\n"
-"span></a></li> </ul> <span>x</span>\""
+msgstr "Este elemento va a ser una traducción al ${language}"
 
 #. Default: "assets"
-#: ../browser/setup.py:139
+#: ../browser/setup.py:140
 msgid "assets_folder_id"
 msgstr "recursos"
 
 #. Default: "Assets"
-#: ../browser/setup.py:142
+#: ../browser/setup.py:143
 msgid "assets_folder_title"
 msgstr "Recursos"
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:44
+#: ../browser/modify.py:46
 msgid "connect_translation"
 msgstr "Conectar traducción"
 
@@ -167,15 +162,13 @@ msgstr "Conectar traducción"
 msgid "content"
 msgstr "Contenido"
 
-#. Default: "If you want to create this object without being a translation press <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">here</a>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "If you want to create this object without being a translation press ${url}"
+#: ../browser/templates/add-form-is-translation.pt:15
 msgid "create-object-without-translation"
-msgstr ""
-"Si quieres crear este contenido sin que sea una traducción, pulse <a href=\\\"${DYNAMIC_CONTENT}\\\" class=\\\"link-\n"
-"overlay\\\">aquí</a>"
+msgstr "Si quieres crear este contenido sin que sea una traducción, pulse ${url}"
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:161
+#: ../browser/menu.py:162
 msgid "create_translation"
 msgstr "Crear ${lang_name}"
 
@@ -185,32 +178,32 @@ msgid "description_after_migration_cleanup"
 msgstr "Este paso arreglará algunas dependencias de la interfaz ITranslatable que se guardan en el catálogo de relaciones. Se deberá ejecutarla solo cuando haya desinstalado LinguaPlone"
 
 #. Default: "Edit {lang_name} with the two-column translation view"
-#: ../browser/menu.py:117
+#: ../browser/menu.py:118
 msgid "description_babeledit_menu"
 msgstr "Editar ${lang_name} con la vista de dos columnas"
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
-#: ../interfaces.py:240
+#: ../interfaces.py:241
 msgid "description_buttons_babel_view_up_to_nr_translations"
 msgstr "Cuando haya muchas traducciones de un elemento, el número de botones que se muestran para la selección de idioma puede que sea demasiado alto para que se muestren de forma correcta. Elija aquí el número de traducciones a partir del cual se mostrará un desplegable en vez de botones. Si introduce cero, indicará que se muestren siempre los botones."
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
-#: ../interfaces.py:221
+#: ../interfaces.py:222
 msgid "description_bypass_languageindependent_field_permission_check"
 msgstr "Cuando se actualiza un elemento con un campo independiente respecto al idioma, ese campo se sincronizará a todos los idiomas. Esto puede producir errores de permisos porque el editor puede que no tenga permiso para actualizar una de las traducciones. Activando esta opción se permitirá saltar esa comprobación de permisos. Esto puede ser peligroso, por lo que tenga en cuenta cualquier situación que pueda crear problemas de seguridad antes de activarla."
 
 #. Default: "Filter using language the content on folder_contents"
-#: ../interfaces.py:198
+#: ../interfaces.py:199
 msgid "description_filter_content"
 msgstr "Filtrar la vista de los contenidos de la carpeta según el idioma"
 
 #. Default: "Is a paying API in order to use google translation service"
-#: ../interfaces.py:256
+#: ../interfaces.py:257
 msgid "description_google_translation_key"
 msgstr "Es un servicio de pago para utilizar el API de traducciones de Google"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:466
+#: ../browser/menu.py:469
 msgid "description_language_folder"
 msgstr "Ir al idioma preferido según las preferencias del usuario"
 
@@ -230,12 +223,12 @@ msgid "description_migration_results"
 msgstr "Aquí verá los resultados de la migración"
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:219
+#: ../browser/menu.py:220
 msgid "description_modify_translations"
 msgstr "Añadir o eliminar traducciones"
 
 #. Default: "After creating a new translation redirecto to babel view"
-#: ../interfaces.py:209
+#: ../interfaces.py:210
 msgid "description_redirect_babel_view"
 msgstr "Redirigir a la vista babel tras crear una nueva traducción"
 
@@ -250,17 +243,17 @@ msgid "description_relocate_content"
 msgstr "Este paso moverá el contenido del portal a la carpeta raíz de idioma correspondiente y primero hará una búsqueda en el portal para encontrar contenido que no está situado correctamente y moverlo a un sitio adecuado. Este paso es destructivo y modificará la estructura de su portal. Asegúrese de haber configurado correctamente los idiomas de su portal adecuadamente."
 
 #. Default: "The default language used for the content and the UI of this site."
-#: ../interfaces.py:268
+#: ../interfaces.py:269
 msgid "description_selector_lookup_translations_policy"
 msgstr "El idioma por defecto que se utilizará para el contenido y el interfaz de este sitio."
 
 #. Default: "Move the translation under another language folder"
-#: ../browser/menu.py:140
+#: ../browser/menu.py:141
 msgid "description_set_language"
 msgstr "Mover la traducción a la carpeta de otro idioma"
 
 #. Default: "Open the language independent assets folder"
-#: ../browser/menu.py:445
+#: ../browser/menu.py:448
 msgid "description_shared_folder"
 msgstr "Abrir la carpeta de recursos compartida entre idiomas"
 
@@ -270,7 +263,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr "Este paso transferirá las relaciones de las traducciones guardadas por LinguaPlone al catálogo de plone.app.multilingual. Este paso no es destructivo y se puede ejecutar tantas veces como sea necesario."
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:166
+#: ../browser/menu.py:167
 msgid "description_translate_into"
 msgstr "Traducir a ${lang_name}"
 
@@ -280,7 +273,7 @@ msgid "description_translation_map"
 msgstr "Mapa de traducciones."
 
 #. Default: "Universal link to the content in user's preferred language"
-#: ../browser/menu.py:239
+#: ../browser/menu.py:241
 msgid "description_universal_link"
 msgstr "Enlace universal al contenido en el idioma preferido del usuario"
 
@@ -290,22 +283,22 @@ msgid "description_update_language"
 msgstr "Idiomas sin traducciones del contenido actual"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:112
+#: ../browser/menu.py:113
 msgid "edit_translation"
 msgstr "Editar ${lang_name}"
 
 #. Default: "Folder's id is not a valid language code"
-#: ../browser/migrator.py:308
+#: ../browser/migrator.py:309
 msgid "folder_to_lrf_id_not_language"
 msgstr "El identificador de la carpeta no es un idioma válido"
 
 #. Default: "Only folders just below the root can be transformed"
-#: ../browser/migrator.py:297
+#: ../browser/migrator.py:298
 msgid "folder_to_lrf_not_next_to_root"
 msgstr "Solo se pueden transformar las carpetas de debajo de la raíz"
 
 #. Default: "Folder has been successfully transformed to a language root folder"
-#: ../browser/migrator.py:331
+#: ../browser/migrator.py:332
 msgid "folder_to_lrf_success"
 msgstr "La carpeta se ha transformado correctamente a una carpeta de idioma"
 
@@ -315,22 +308,22 @@ msgid "heading_available_translations"
 msgstr "Traducciones disponibles para este elemento"
 
 #. Default: "Use buttons in the bable view for up to how many translations?"
-#: ../interfaces.py:236
+#: ../interfaces.py:237
 msgid "heading_buttons_babel_view_up_to_nr_translations"
 msgstr "¿Utilizar botones en la vista babel?"
 
 #. Default: "Bypass language independent field permission check"
-#: ../interfaces.py:218
+#: ../interfaces.py:219
 msgid "heading_bypass_languageindependent_field_permission_check"
 msgstr "Saltar las comprobaciones de permisos en campos independientes respecto al idioma"
 
 #. Default: "Filter content by language."
-#: ../interfaces.py:195
+#: ../interfaces.py:196
 msgid "heading_filter_content"
 msgstr "Filtrar contenido por idioma"
 
 #. Default: "Google Translation API Key"
-#: ../interfaces.py:253
+#: ../interfaces.py:254
 msgid "heading_google_translation_key"
 msgstr "Google Translation API Key"
 
@@ -355,12 +348,12 @@ msgid "heading_not_available_in_language"
 msgstr "No está disponible en ${language}"
 
 #. Default: "Redirect on creation to babel view."
-#: ../interfaces.py:206
+#: ../interfaces.py:207
 msgid "heading_redirect_babel_view"
 msgstr "Redirigir a la vista babel tras la creación"
 
 #. Default: "The policy used to determine how the lookup for available translations will be made by the language selector."
-#: ../interfaces.py:264
+#: ../interfaces.py:265
 msgid "heading_selector_lookup_translations_policy"
 msgstr "La política que se utilizará para encontrar las traducciones disponibles en el selector de idioma"
 
@@ -373,6 +366,10 @@ msgstr "Mapa de traducciones de plone.app.multilingual"
 #: ../browser/templates/migration.pt:118
 msgid "help_reindex_language_index"
 msgstr "La migración del contenido LinguaPlone depende de un índice de idioma actualizado. Utilice este paso para actualizar este índice. Atención: dependiendo del número de elementos de su portal, esto puede durar mucho tiempo."
+
+#: ../browser/templates/add-form-is-translation.pt:15
+msgid "here"
+msgstr "aquí"
 
 #. Default: "All translations"
 #: ../browser/templates/mmap.pt:75
@@ -395,7 +392,7 @@ msgid "label_cleanup"
 msgstr "Acciones de limpieza"
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:37
+#: ../browser/modify.py:39
 msgid "label_connect_translation"
 msgstr "Conectar traducción"
 
@@ -436,7 +433,7 @@ msgid "label_total_relations"
 msgstr "Número de relaciones modificadas:"
 
 #. Default: "Translate"
-#: ../browser/menu.py:491
+#: ../browser/menu.py:494
 msgid "label_translate_menu"
 msgstr "Traducciones"
 
@@ -451,7 +448,7 @@ msgid "label_translations_should_be_here"
 msgstr "Las traducciones disponibles deberían mostrarse aquí"
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:462
+#: ../browser/menu.py:465
 msgid "language_folder"
 msgstr "Volver a la carpeta del idioma"
 
@@ -476,7 +473,7 @@ msgid "legend_transfer_multilingual_catalog_info"
 msgstr "Paso 2 - Transferir la información del catálogo"
 
 #. Default: "This form allows you to connect a currently existing translations of the current object."
-#: ../browser/modify.py:38
+#: ../browser/modify.py:40
 msgid "long_description_connect_translation"
 msgstr "Este formulario le ayuda a conectar las traducciones existentes con este contenido"
 
@@ -496,7 +493,7 @@ msgid "not_configured_for_multiple_languages"
 msgstr "Su sitio no está configurado para soportar más de un idioma, pero ha instalado el soporte multiidioma para contenido. Puede añadir más idiomas desde la ${control-panel-link}."
 
 #. Default: "All the configuration of a multilingual Plone site"
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid "pam_controlpanel_description"
 msgstr "Toda la configuración multiidioma de Plone"
 
@@ -511,7 +508,7 @@ msgid "relation_migration_with_not_needed"
 msgstr "Su portal no tiene catálogo de relaciones y por lo tanto no es necesario ejecutar este paso."
 
 #. Default: "Open ${title} folder"
-#: ../browser/menu.py:440
+#: ../browser/menu.py:443
 msgid "shared_folder"
 msgstr "Ir a la carpeta ${title}"
 
@@ -526,27 +523,27 @@ msgid "title_language"
 msgstr "Idioma"
 
 #. Default: "Manage translations"
-#: ../browser/menu.py:215
+#: ../browser/menu.py:216
 msgid "title_modify_translations"
 msgstr "Modificar traducciones..."
 
 #. Default: "Change content language"
-#: ../browser/menu.py:136
+#: ../browser/menu.py:137
 msgid "title_set_language"
 msgstr "Modificar idioma del contenido"
 
 #. Default: "Folder translation"
-#: ../browser/menu.py:258
+#: ../browser/menu.py:260
 msgid "title_translate_current_folder"
 msgstr "Traducción de la carpeta"
 
 #. Default: "Item translation"
-#: ../browser/menu.py:422
+#: ../browser/menu.py:425
 msgid "title_translate_current_item"
 msgstr "Traducción del elemento"
 
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:492
+#: ../browser/menu.py:495
 msgid "title_translate_menu"
 msgstr "Gestionar traducciones de su contenido."
 
@@ -561,7 +558,7 @@ msgid "translation_to"
 msgstr "Traducir a ${language}"
 
 #. Default: "Universal link"
-#: ../browser/menu.py:235
+#: ../browser/menu.py:237
 msgid "universal_link"
 msgstr "Enlace universal"
 

--- a/src/plone/app/multilingual/locales/eu/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/eu/LC_MESSAGES/plone.app.multilingual.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone.app.multilingual\n"
-"POT-Creation-Date: 2017-07-13 21:35+0000\n"
-"PO-Revision-Date: 2017-08-04 14:07+0200\n"
+"POT-Creation-Date: 2018-03-19 06:49+0000\n"
+"PO-Revision-Date: 2018-03-19 07:52+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: eu <eu@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -19,15 +19,15 @@ msgstr ""
 "Language: eu\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: ../browser/migrator.py:85
+#: ../browser/migrator.py:86
 msgid "After migration relation cleanup"
 msgstr "Migrazioaren osteko garbiketa"
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:60
 msgid "Cancel"
 msgstr "Utzi"
 
-#: ../browser/controlpanel.py:65
+#: ../browser/controlpanel.py:63
 msgid "Changes canceled."
 msgstr "Aldaketak bertan behera utzi dira"
 
@@ -35,7 +35,7 @@ msgstr "Aldaketak bertan behera utzi dira"
 msgid "Cleanup"
 msgstr "Garbitu"
 
-#: ../browser/controlpanel.py:49
+#: ../browser/controlpanel.py:47
 msgid "Default language not in available languages"
 msgstr "Defektuzko hizkuntza ez dago webguneko hizkuntzen artean"
 
@@ -47,7 +47,7 @@ msgstr "Hala ere, hemen dituzu hizkuntza batzuetan eginda dauden elementu honen 
 msgid "Install to enable multilingual content support with plone.app.multilingual"
 msgstr "Eduki eleanitza izateko konfigurazioa aktibatu: plone.app.multilingual"
 
-#: ../browser/translate.py:69
+#: ../browser/translate.py:70
 msgid "Invalid field"
 msgstr "Eremua ez da zuzena"
 
@@ -55,7 +55,7 @@ msgstr "Eremua ez da zuzena"
 msgid "Language control panel"
 msgstr "Hizkuntzen kontrol-panela"
 
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Make this content type multilingual aware"
 msgstr "Elementu-mota hauek itzulgarri egin"
 
@@ -64,15 +64,15 @@ msgid "Move"
 msgstr "Mugitu"
 
 #. Default: "Multilingual"
-#: ../interfaces.py:183
+#: ../interfaces.py:184
 msgid "Multilingual"
 msgstr "Multilingual"
 
-#: ../browser/controlpanel.py:32
+#: ../browser/controlpanel.py:30
 msgid "Multilingual Settings"
 msgstr "Eleaniztasun-aukerak"
 
-#: ../configure.zcml:151 ../dx/configure.zcml:36
+#: ../configure.zcml:151 ../dx/configure.zcml:37
 msgid "Multilingual Support"
 msgstr "Eleaniztasun-aukerak"
 
@@ -80,11 +80,11 @@ msgstr "Eleaniztasun-aukerak"
 msgid "Multilingual Support [uninstall]"
 msgstr "Eleaniztasun-aukerak [kendu]"
 
-#: ../browser/translate.py:54
+#: ../browser/translate.py:55
 msgid "Need a field"
 msgstr "Eremua behar da"
 
-#: ../browser/controlpanel.py:174
+#: ../browser/controlpanel.py:172
 msgid "Not translated"
 msgstr "Itzuli gabe"
 
@@ -96,19 +96,19 @@ msgstr "Berindexatu"
 msgid "Relocate"
 msgstr "Birkokatu"
 
-#: ../browser/migrator.py:127
+#: ../browser/migrator.py:128
 msgid "Relocate content to the proper root language folder"
 msgstr "Edukia dagokion hizkuntzaren karpetan kokatu"
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:36
 msgid "Save"
 msgstr "Gorde"
 
-#: ../interfaces.py:169
+#: ../interfaces.py:170
 msgid "Search for closest translation in parent's content chain."
 msgstr "Gurasoengandik hasita itzulpena duen elementurik gertukoena aurkitu."
 
-#: ../interfaces.py:172
+#: ../interfaces.py:173
 msgid "Show user dialog with information about the available translations."
 msgstr "Itzulpenik ez dagoela dioen mezua erakutsi."
 
@@ -128,7 +128,7 @@ msgstr "Elementu honek ez du itzulpenenik. Atariaren sarrerara itzuli zaitezke"
 msgid "Transfer"
 msgstr "Migratu"
 
-#: ../browser/migrator.py:50
+#: ../browser/migrator.py:51
 msgid "Transfer multilingual catalog information"
 msgstr "LinguaPloneren informazioa katalogora migratu"
 
@@ -140,23 +140,23 @@ msgstr "Desinstalatu, eduki eleanitza izateko konfigurazioa desaktibatu: plone.a
 msgid "Update bundle regristration"
 msgstr "Bildumak berriz erregistratu"
 
-#. Default: "This object is going to be a translation to ${DYNAMIC_CONTENT} from: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "This object is going to be a translation to ${language} from:"
+#: ../browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
-msgstr "Elementu hau ${DYNAMIC_CONTENT}-rako itzulpen bat izango da, jatorrizkoak: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>\""
+msgstr "Elementu hau ${language}-rako itzulpen bat izango da."
 
 #. Default: "assets"
-#: ../browser/setup.py:139
+#: ../browser/setup.py:140
 msgid "assets_folder_id"
 msgstr "media"
 
 #. Default: "Assets"
-#: ../browser/setup.py:142
+#: ../browser/setup.py:143
 msgid "assets_folder_title"
 msgstr "Media"
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:44
+#: ../browser/modify.py:46
 msgid "connect_translation"
 msgstr "Itzulpenak lotu"
 
@@ -164,13 +164,13 @@ msgstr "Itzulpenak lotu"
 msgid "content"
 msgstr "Edukia"
 
-#. Default: "If you want to create this object without being a translation press <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">here</a>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "If you want to create this object without being a translation press ${url}"
+#: ../browser/templates/add-form-is-translation.pt:15
 msgid "create-object-without-translation"
-msgstr "Elementu hau itzulpena izan gabe sortzeko <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">sakatu hemen</a>"
+msgstr "Elementu hau itzulpena izan gabe sortzeko sakatu ${url}"
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:161
+#: ../browser/menu.py:162
 msgid "create_translation"
 msgstr "${lang_name} itzulpena sortu"
 
@@ -180,32 +180,32 @@ msgid "description_after_migration_cleanup"
 msgstr "Pausu honek ITranslatabe interfazearen dependentzia batzuk kkonponduko ditu. LinguaPlone guztiz desinstalatuta dagoenen bakarrik exekutatu behar da."
 
 #. Default: "Edit {lang_name} with the two-column translation view"
-#: ../browser/menu.py:117
+#: ../browser/menu.py:118
 msgid "description_babeledit_menu"
 msgstr "${lang_name} editatu bi zutabetako bistan"
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
-#: ../interfaces.py:240
+#: ../interfaces.py:241
 msgid "description_buttons_babel_view_up_to_nr_translations"
 msgstr "Elementu baten itzulpen asko dagoenean, agertzen den botoi kopurua gehiegizkoa izan daiteke pantailan ondo ikusteko. Ezarri hemen noiz agertuko den menu desplegablea botoiak beharrean. Zero jartzen baduzu, beti botoiak agertuko dira."
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
-#: ../interfaces.py:221
+#: ../interfaces.py:222
 msgid "description_bypass_languageindependent_field_permission_check"
 msgstr "Hizkuntzarekiko independentea den eremu bat duen elementu bat aldatzen denean, eremuaren balioa beste hizkuntzetara sinkronizatuko da. Horrek baimen arazoak eman ditzake editoreak beste hizkuntzetako elementuak aldatzeko baimenik ez badu. Hau aktibatzen baduzu, baimenen egiaztaketa ez da egingo. Arriskutsua ere izan daiteke, beraz aktibatu aurretik aztertu zure baimen-sistema."
 
 #. Default: "Filter using language the content on folder_contents"
-#: ../interfaces.py:198
+#: ../interfaces.py:199
 msgid "description_filter_content"
 msgstr "Karpetaren edukien bistan (folder_contents), edukia hizkuntzaren arabera filtratu"
 
 #. Default: "Is a paying API in order to use google translation service"
-#: ../interfaces.py:256
+#: ../interfaces.py:257
 msgid "description_google_translation_key"
 msgstr "Google-ren itzulpen zerbitzua erabiltzeko API gakoa (ordainpeko zerbitzua)"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:466
+#: ../browser/menu.py:469
 msgid "description_language_folder"
 msgstr "Erabiltzailearen nabigatzailearen hobespenek dioten hizkuntzara joan"
 
@@ -225,12 +225,12 @@ msgid "description_migration_results"
 msgstr "Hemen migrazioaren emaitzak ikusiko dituzu"
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:219
+#: ../browser/menu.py:220
 msgid "description_modify_translations"
 msgstr "Itzulpenak gehitu edo ezabatu"
 
 #. Default: "After creating a new translation redirecto to babel view"
-#: ../interfaces.py:209
+#: ../interfaces.py:210
 msgid "description_redirect_babel_view"
 msgstr "Itzulpen berria sortu ostean babel bistara joan."
 
@@ -245,17 +245,17 @@ msgid "description_relocate_content"
 msgstr "Pausu honek, elementuak beren hizkuntzaren arabera dagokien tokira mugituko ditu. Horretarako eduki zuhaitzean zehar gaizki kokatuta dauden elementuak topatuko ditu (adibidez, gaztelania hizkuntza gisa duten elementuak euskarazko zuhaitzean) eta dagokien tokira mugituko ditu. Pausu hau atzeraezina da eta zure eduki-zuhaitza aldatuko du. Ziurta zaitez aurrez zure atariaren hizkuntzak ondo konfiguratu dituzula 'Hizkuntzen kontrol-panelean'. Zerbitzariaren errore-erregistroan agertuko dira mugitu beharreko elementuen datuak."
 
 #. Default: "The default language used for the content and the UI of this site."
-#: ../interfaces.py:268
+#: ../interfaces.py:269
 msgid "description_selector_lookup_translations_policy"
 msgstr "Defektuzko hizkuntza erabiltzen da edukiarentzat eta interfazearentzat."
 
 #. Default: "Move the translation under another language folder"
-#: ../browser/menu.py:140
+#: ../browser/menu.py:141
 msgid "description_set_language"
 msgstr "Elementu hau beste hizkuntza batera mugitu"
 
 #. Default: "Open the language independent assets folder"
-#: ../browser/menu.py:445
+#: ../browser/menu.py:448
 msgid "description_shared_folder"
 msgstr "Hizkuntzen artean partekatutako karpeta erakutsi"
 
@@ -265,7 +265,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr "Pausu honek LinguaPloneren elementuen arteko erlazioak sistema berrira migratuko ditu. Pausu honek ez du ezer deusezten eta nahi adina aldiz exekutatu daiteke."
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:166
+#: ../browser/menu.py:167
 msgid "description_translate_into"
 msgstr "${lang_name} hizkuntzara itzuli"
 
@@ -275,7 +275,7 @@ msgid "description_translation_map"
 msgstr "Itzulpenen mapa"
 
 #. Default: "Universal link to the content in user's preferred language"
-#: ../browser/menu.py:239
+#: ../browser/menu.py:241
 msgid "description_universal_link"
 msgstr "Erabiltzailearen hizkuntzan ikusiko den elementuaren lotura unibertsala"
 
@@ -285,22 +285,22 @@ msgid "description_update_language"
 msgstr "Uneko elementuaren itzuli gabeko bertsioak"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:112
+#: ../browser/menu.py:113
 msgid "edit_translation"
 msgstr "${lang_name} itzulpena editatu"
 
 #. Default: "Folder's id is not a valid language code"
-#: ../browser/migrator.py:308
+#: ../browser/migrator.py:309
 msgid "folder_to_lrf_id_not_language"
 msgstr "Karpetaren id-a ez da hizkuntza-kode zuzena"
 
 #. Default: "Only folders just below the root can be transformed"
-#: ../browser/migrator.py:297
+#: ../browser/migrator.py:298
 msgid "folder_to_lrf_not_next_to_root"
 msgstr "Erroan dauden karpetak bakarrik aldatu daitezke"
 
 #. Default: "Folder has been successfully transformed to a language root folder"
-#: ../browser/migrator.py:331
+#: ../browser/migrator.py:332
 msgid "folder_to_lrf_success"
 msgstr "Karpeta, Hizkuntzen Erro Karpeta izatera ondo aldatu da"
 
@@ -310,22 +310,22 @@ msgid "heading_available_translations"
 msgstr "Elementu honek dituen itzulpenak"
 
 #. Default: "Use buttons in the bable view for up to how many translations?"
-#: ../interfaces.py:236
+#: ../interfaces.py:237
 msgid "heading_buttons_babel_view_up_to_nr_translations"
 msgstr "Babel bistan botoiak erabili hizkuntza kopuru hau eduki arte:"
 
 #. Default: "Bypass language independent field permission check"
-#: ../interfaces.py:218
+#: ../interfaces.py:219
 msgid "heading_bypass_languageindependent_field_permission_check"
 msgstr "Hizkuntzarekiko independenteak diren eremuen baimen-kontrola saltatu."
 
 #. Default: "Filter content by language."
-#: ../interfaces.py:195
+#: ../interfaces.py:196
 msgid "heading_filter_content"
 msgstr "Edukia hizkuntzaren arabera filtratu."
 
 #. Default: "Google Translation API Key"
-#: ../interfaces.py:253
+#: ../interfaces.py:254
 msgid "heading_google_translation_key"
 msgstr "Google Translate API gakoa"
 
@@ -350,12 +350,12 @@ msgid "heading_not_available_in_language"
 msgstr "Ez dago ${language }z"
 
 #. Default: "Redirect on creation to babel view."
-#: ../interfaces.py:206
+#: ../interfaces.py:207
 msgid "heading_redirect_babel_view"
 msgstr "Sortzerakoan babel bistara berbideratu"
 
 #. Default: "The policy used to determine how the lookup for available translations will be made by the language selector."
-#: ../interfaces.py:264
+#: ../interfaces.py:265
 msgid "heading_selector_lookup_translations_policy"
 msgstr "Hizkuntza aldatzerakoan erabiliko den politika"
 
@@ -368,6 +368,10 @@ msgstr "Edukiaren itzulpenen mapa"
 #: ../browser/templates/migration.pt:118
 msgid "help_reindex_language_index"
 msgstr "LinguaPlonetik migrazioa egiteko hizkuntzari dagokion indizea guztiz eguneratuta egon behar da. Horretarako erabili orrialde hau. Oharra: zure atariak duen elementu-kopuruaren arabera, prozesu honek denbora asko har lezake."
+
+#: ../browser/templates/add-form-is-translation.pt:15
+msgid "here"
+msgstr "hemen"
 
 #. Default: "All translations"
 #: ../browser/templates/mmap.pt:75
@@ -390,7 +394,7 @@ msgid "label_cleanup"
 msgstr "Garbiketa-ekintzak"
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:37
+#: ../browser/modify.py:39
 msgid "label_connect_translation"
 msgstr "Itzulpena lotu"
 
@@ -431,7 +435,7 @@ msgid "label_total_relations"
 msgstr "Ukitutako erlazio kopurua:"
 
 #. Default: "Translate"
-#: ../browser/menu.py:491
+#: ../browser/menu.py:494
 msgid "label_translate_menu"
 msgstr "Itzuli..."
 
@@ -446,7 +450,7 @@ msgid "label_translations_should_be_here"
 msgstr "Elementu honen itzulpenak hemen agertu beharko lirateke"
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:462
+#: ../browser/menu.py:465
 msgid "language_folder"
 msgstr "Hizkuntzaren karpetara joan"
 
@@ -471,7 +475,7 @@ msgid "legend_transfer_multilingual_catalog_info"
 msgstr "2. pausua - Itzulpenen informazioa migratu"
 
 #. Default: "This form allows you to connect a currently existing translations of the current object."
-#: ../browser/modify.py:38
+#: ../browser/modify.py:40
 msgid "long_description_connect_translation"
 msgstr "Formulario honek uneko elementua webgunean jada existitzen den beste elementu baten itzulpen gisa gordetzeko aukera ematen dizu"
 
@@ -491,7 +495,7 @@ msgid "not_configured_for_multiple_languages"
 msgstr "Zure ataria ez dago hizkuntza bat baino gehiago erabiltzeko konfiguratuta, baina eduki eleanitza izateko produktua instalatuta dago. Hizkuntza gehiago hemendik gehitu dezakezu: ${control-panel-link}."
 
 #. Default: "All the configuration of a multilingual Plone site"
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid "pam_controlpanel_description"
 msgstr "plone.app.multilingual produktuaren konfigurazioa. Hizkuntzarik ez duten hizkuntzei defektuzko hizkuntza ezarri nahi badiezu, edo elementuak hizkuntzaren arabera dagokien tokira mugitu nahi baditzu, joan aukera gehigarrietara."
 
@@ -506,7 +510,7 @@ msgid "relation_migration_with_not_needed"
 msgstr "Zure atariak ez du erlazio-kataloorik eta beraz, ez pausu hau ez da beharrezkoa."
 
 #. Default: "Open ${title} folder"
-#: ../browser/menu.py:440
+#: ../browser/menu.py:443
 msgid "shared_folder"
 msgstr "${title} karpeta ireki"
 
@@ -521,27 +525,27 @@ msgid "title_language"
 msgstr "Hizkuntza"
 
 #. Default: "Manage translations"
-#: ../browser/menu.py:215
+#: ../browser/menu.py:216
 msgid "title_modify_translations"
 msgstr "Itzulpenak kudeatu"
 
 #. Default: "Change content language"
-#: ../browser/menu.py:136
+#: ../browser/menu.py:137
 msgid "title_set_language"
 msgstr "Elementuaren hizkuntza aldatu"
 
 #. Default: "Folder translation"
-#: ../browser/menu.py:258
+#: ../browser/menu.py:260
 msgid "title_translate_current_folder"
 msgstr "Karpetaren itzulpena"
 
 #. Default: "Item translation"
-#: ../browser/menu.py:422
+#: ../browser/menu.py:425
 msgid "title_translate_current_item"
 msgstr "Elementuaren itzulpena"
 
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:492
+#: ../browser/menu.py:495
 msgid "title_translate_menu"
 msgstr "Zure edukiaren itzulpenak kudeatu."
 
@@ -556,7 +560,7 @@ msgid "translation_to"
 msgstr "Itzulpena: ${language}"
 
 #. Default: "Universal link"
-#: ../browser/menu.py:235
+#: ../browser/menu.py:237
 msgid "universal_link"
 msgstr "Lotura Unibertsala"
 

--- a/src/plone/app/multilingual/locales/fi/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/fi/LC_MESSAGES/plone.app.multilingual.po
@@ -1,9 +1,9 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-07-13 21:35+0000\n"
-"PO-Revision-Date: 2015-02-18 11:45+0200\n"
-"Last-Translator: Asko Soukka <asko.soukka@iki.fi>\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: 2018-03-19 06:49+0000\n"
+"PO-Revision-Date: 2018-03-19 07:53+0100\n"
+"Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: Finnish <https://github.com/collective>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -13,25 +13,26 @@ msgstr ""
 "Language-Name: Finnish\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fi\n"
+"X-Generator: Poedit 1.8.7.1\n"
 
-#: ../browser/migrator.py:85
+#: ../browser/migrator.py:86
 msgid "After migration relation cleanup"
 msgstr "Korjaa viittaukset sisällössä migraation jälkeen"
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:60
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: ../browser/controlpanel.py:65
+#: ../browser/controlpanel.py:63
 msgid "Changes canceled."
 msgstr "Muutokset peruttu."
 
-#: ../browser/templates/cleanup.pt:79
-#: ../browser/templates/migration.pt:250
+#: ../browser/templates/cleanup.pt:79 ../browser/templates/migration.pt:250
 msgid "Cleanup"
 msgstr "Siivous"
 
-#: ../browser/controlpanel.py:49
+#: ../browser/controlpanel.py:47
 msgid "Default language not in available languages"
 msgstr "Oletuskieli ei ole sallittujen kielten joukossa"
 
@@ -43,7 +44,7 @@ msgstr "Sivusta löytyy käännös näille kielille:"
 msgid "Install to enable multilingual content support with plone.app.multilingual"
 msgstr ""
 
-#: ../browser/translate.py:69
+#: ../browser/translate.py:70
 msgid "Invalid field"
 msgstr "Virheellinen kenttä"
 
@@ -51,7 +52,7 @@ msgstr "Virheellinen kenttä"
 msgid "Language control panel"
 msgstr "Monikielisen sisällönhallinnan asetukset"
 
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Make this content type multilingual aware"
 msgstr ""
 
@@ -60,16 +61,15 @@ msgid "Move"
 msgstr "Siirrä"
 
 #. Default: "Multilingual"
-#: ../interfaces.py:183
+#: ../interfaces.py:184
 msgid "Multilingual"
 msgstr ""
 
-#: ../browser/controlpanel.py:32
+#: ../browser/controlpanel.py:30
 msgid "Multilingual Settings"
 msgstr "Monikielisen sisällönhallinnan asetukset"
 
-#: ../configure.zcml:151
-#: ../dx/configure.zcml:36
+#: ../configure.zcml:151 ../dx/configure.zcml:37
 msgid "Multilingual Support"
 msgstr ""
 
@@ -77,11 +77,11 @@ msgstr ""
 msgid "Multilingual Support [uninstall]"
 msgstr ""
 
-#: ../browser/translate.py:54
+#: ../browser/translate.py:55
 msgid "Need a field"
 msgstr "Kenttä puuttuu"
 
-#: ../browser/controlpanel.py:174
+#: ../browser/controlpanel.py:172
 msgid "Not translated"
 msgstr "Ei käännetty"
 
@@ -93,19 +93,19 @@ msgstr "Indeksoi uudelleen"
 msgid "Relocate"
 msgstr "Siirrä"
 
-#: ../browser/migrator.py:127
+#: ../browser/migrator.py:128
 msgid "Relocate content to the proper root language folder"
 msgstr "Siirrä sivu sen oikeaan kielikansioon"
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:36
 msgid "Save"
 msgstr ""
 
-#: ../interfaces.py:169
+#: ../interfaces.py:170
 msgid "Search for closest translation in parent's content chain."
 msgstr "Etsi lähin käännetty sivu kansiohierarkian perusteella"
 
-#: ../interfaces.py:172
+#: ../interfaces.py:173
 msgid "Show user dialog with information about the available translations."
 msgstr "Anna käyttäjän valita joku saatavilla olevista käännöksistä"
 
@@ -125,7 +125,7 @@ msgstr "Tästä sivusta ei ole vielä yhtään käännöstä. Siirry takaisin et
 msgid "Transfer"
 msgstr "Siirrä"
 
-#: ../browser/migrator.py:50
+#: ../browser/migrator.py:51
 msgid "Transfer multilingual catalog information"
 msgstr "Siirrä monikielisen sisällön katalogitiedot"
 
@@ -137,23 +137,23 @@ msgstr ""
 msgid "Update bundle regristration"
 msgstr ""
 
-#. Default: "This object is going to be a translation to ${DYNAMIC_CONTENT} from: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "This object is going to be a translation to ${language} from:"
+#: ../browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
 msgstr ""
 
 #. Default: "assets"
-#: ../browser/setup.py:139
+#: ../browser/setup.py:140
 msgid "assets_folder_id"
 msgstr ""
 
 #. Default: "Assets"
-#: ../browser/setup.py:142
+#: ../browser/setup.py:143
 msgid "assets_folder_title"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:44
+#: ../browser/modify.py:46
 msgid "connect_translation"
 msgstr ""
 
@@ -161,13 +161,14 @@ msgstr ""
 msgid "content"
 msgstr "Sisältö"
 
-#. Default: "If you want to create this object without being a translation press <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">here</a>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "If you want to create this object without being a translation press ${url}"
+#: ../browser/templates/add-form-is-translation.pt:15
+#, fuzzy
 msgid "create-object-without-translation"
-msgstr "<a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">Haluan luoda tämän sivun, mutta en halua siitä tulevan linkitettyä käännöstä.</a>"
+msgstr "Haluan luoda tämän sivun, mutta en halua siitä tulevan linkitettyä käännöstä ${url}"
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:161
+#: ../browser/menu.py:162
 msgid "create_translation"
 msgstr "Käännä: ${lang_name}"
 
@@ -177,32 +178,32 @@ msgid "description_after_migration_cleanup"
 msgstr ""
 
 #. Default: "Edit {lang_name} with the two-column translation view"
-#: ../browser/menu.py:117
+#: ../browser/menu.py:118
 msgid "description_babeledit_menu"
 msgstr "Muokkaa käännöstä (${lang_name}) kaksipalstaisessa kääntäjässä"
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
-#: ../interfaces.py:240
+#: ../interfaces.py:241
 msgid "description_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
-#: ../interfaces.py:221
+#: ../interfaces.py:222
 msgid "description_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter using language the content on folder_contents"
-#: ../interfaces.py:198
+#: ../interfaces.py:199
 msgid "description_filter_content"
 msgstr "Suodata kansioiden sisältö valitun kielen mukaan"
 
 #. Default: "Is a paying API in order to use google translation service"
-#: ../interfaces.py:256
+#: ../interfaces.py:257
 msgid "description_google_translation_key"
 msgstr "Maksullinen API-avain Googlen käännöspalvelun käyttöön"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:466
+#: ../browser/menu.py:469
 msgid "description_language_folder"
 msgstr "Siirry käyttäjän selaimen suosittaman kielen kielikansioon"
 
@@ -222,12 +223,12 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:219
+#: ../browser/menu.py:220
 msgid "description_modify_translations"
 msgstr ""
 
 #. Default: "After creating a new translation redirecto to babel view"
-#: ../interfaces.py:209
+#: ../interfaces.py:210
 msgid "description_redirect_babel_view"
 msgstr ""
 
@@ -242,17 +243,17 @@ msgid "description_relocate_content"
 msgstr ""
 
 #. Default: "The default language used for the content and the UI of this site."
-#: ../interfaces.py:268
+#: ../interfaces.py:269
 msgid "description_selector_lookup_translations_policy"
 msgstr ""
 
 #. Default: "Move the translation under another language folder"
-#: ../browser/menu.py:140
+#: ../browser/menu.py:141
 msgid "description_set_language"
 msgstr "Vaihda sisällön kieli ja siirrä sisältö toiselle kielialueelle"
 
 #. Default: "Open the language independent assets folder"
-#: ../browser/menu.py:445
+#: ../browser/menu.py:448
 msgid "description_shared_folder"
 msgstr "Siirry kieliriippumattomaan jaetun sisällön kansioon"
 
@@ -262,7 +263,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:166
+#: ../browser/menu.py:167
 msgid "description_translate_into"
 msgstr "Tee tästä sivustä uusi käännös kielelle ${lang_name}"
 
@@ -272,7 +273,7 @@ msgid "description_translation_map"
 msgstr "Käännöskartta"
 
 #. Default: "Universal link to the content in user's preferred language"
-#: ../browser/menu.py:239
+#: ../browser/menu.py:241
 msgid "description_universal_link"
 msgstr "Kieliriippumaton linkki ohjaa suoraan käännöseen käyttäjän omalla kielellä"
 
@@ -282,22 +283,22 @@ msgid "description_update_language"
 msgstr "Kielet, joille tätä sivua ei ole käännetty"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:112
+#: ../browser/menu.py:113
 msgid "edit_translation"
 msgstr "Muokkaa: ${lang_name}"
 
 #. Default: "Folder's id is not a valid language code"
-#: ../browser/migrator.py:308
+#: ../browser/migrator.py:309
 msgid "folder_to_lrf_id_not_language"
 msgstr ""
 
 #. Default: "Only folders just below the root can be transformed"
-#: ../browser/migrator.py:297
+#: ../browser/migrator.py:298
 msgid "folder_to_lrf_not_next_to_root"
 msgstr ""
 
 #. Default: "Folder has been successfully transformed to a language root folder"
-#: ../browser/migrator.py:331
+#: ../browser/migrator.py:332
 msgid "folder_to_lrf_success"
 msgstr ""
 
@@ -307,22 +308,22 @@ msgid "heading_available_translations"
 msgstr "Tämän sivun käännökset"
 
 #. Default: "Use buttons in the bable view for up to how many translations?"
-#: ../interfaces.py:236
+#: ../interfaces.py:237
 msgid "heading_buttons_babel_view_up_to_nr_translations"
 msgstr "Kuinka monelle kielelle näyettään painikkeet rinnakkaiskääntäjässä?"
 
 #. Default: "Bypass language independent field permission check"
-#: ../interfaces.py:218
+#: ../interfaces.py:219
 msgid "heading_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter content by language."
-#: ../interfaces.py:195
+#: ../interfaces.py:196
 msgid "heading_filter_content"
 msgstr "Suodata sivut kielen mukaan"
 
 #. Default: "Google Translation API Key"
-#: ../interfaces.py:253
+#: ../interfaces.py:254
 msgid "heading_google_translation_key"
 msgstr "Google-käännöspalvelun API-avain"
 
@@ -347,12 +348,12 @@ msgid "heading_not_available_in_language"
 msgstr ""
 
 #. Default: "Redirect on creation to babel view."
-#: ../interfaces.py:206
+#: ../interfaces.py:207
 msgid "heading_redirect_babel_view"
 msgstr ""
 
 #. Default: "The policy used to determine how the lookup for available translations will be made by the language selector."
-#: ../interfaces.py:264
+#: ../interfaces.py:265
 msgid "heading_selector_lookup_translations_policy"
 msgstr ""
 
@@ -364,6 +365,10 @@ msgstr ""
 #. Default: "The migration of LinguaPlone content depends on an up-to-date Language index. Use this step to refresh this index. Warning: Depending on the number of items in your site, this can take a considerable amount of time."
 #: ../browser/templates/migration.pt:118
 msgid "help_reindex_language_index"
+msgstr ""
+
+#: ../browser/templates/add-form-is-translation.pt:15
+msgid "here"
 msgstr ""
 
 #. Default: "All translations"
@@ -387,13 +392,12 @@ msgid "label_cleanup"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:37
+#: ../browser/modify.py:39
 msgid "label_connect_translation"
 msgstr ""
 
 #. Default: "General"
-#: ../browser/templates/cleanup.pt:38
-#: ../browser/templates/migration.pt:73
+#: ../browser/templates/cleanup.pt:38 ../browser/templates/migration.pt:73
 msgid "label_general"
 msgstr ""
 
@@ -429,13 +433,12 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:491
+#: ../browser/menu.py:494
 msgid "label_translate_menu"
 msgstr "Käännä"
 
 #. Default: "Translation Map"
-#: ../browser/templates/cleanup.pt:43
-#: ../browser/templates/migration.pt:78
+#: ../browser/templates/cleanup.pt:43 ../browser/templates/migration.pt:78
 msgid "label_translation_map"
 msgstr ""
 
@@ -445,7 +448,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:462
+#: ../browser/menu.py:465
 msgid "language_folder"
 msgstr ""
 
@@ -470,7 +473,7 @@ msgid "legend_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "This form allows you to connect a currently existing translations of the current object."
-#: ../browser/modify.py:38
+#: ../browser/modify.py:40
 msgid "long_description_connect_translation"
 msgstr ""
 
@@ -490,7 +493,7 @@ msgid "not_configured_for_multiple_languages"
 msgstr ""
 
 #. Default: "All the configuration of a multilingual Plone site"
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid "pam_controlpanel_description"
 msgstr "Kaikki monikielisen sisällönhallinnan asetukset. (Jos haluat asettaa oletuskielen kaikille sivuille, jolla ei ole vielä kieltä, ja siirtää sivut saman sisällön juurihakemistosta oletuskielen hakemistoon, valitse migraatio.)"
 
@@ -505,7 +508,7 @@ msgid "relation_migration_with_not_needed"
 msgstr ""
 
 #. Default: "Open ${title} folder"
-#: ../browser/menu.py:440
+#: ../browser/menu.py:443
 msgid "shared_folder"
 msgstr "Avaa ${title}-kansio"
 
@@ -520,27 +523,27 @@ msgid "title_language"
 msgstr "Kieli"
 
 #. Default: "Manage translations"
-#: ../browser/menu.py:215
+#: ../browser/menu.py:216
 msgid "title_modify_translations"
 msgstr "Hallitse käännöksiä"
 
 #. Default: "Change content language"
-#: ../browser/menu.py:136
+#: ../browser/menu.py:137
 msgid "title_set_language"
 msgstr "Määritä tämän sivun kieli"
 
 #. Default: "Folder translation"
-#: ../browser/menu.py:258
+#: ../browser/menu.py:260
 msgid "title_translate_current_folder"
 msgstr "Kansion käännökset"
 
 #. Default: "Item translation"
-#: ../browser/menu.py:422
+#: ../browser/menu.py:425
 msgid "title_translate_current_item"
 msgstr "Sivun käännökset"
 
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:492
+#: ../browser/menu.py:495
 msgid "title_translate_menu"
 msgstr "Hallitse käännöksiä"
 
@@ -555,7 +558,7 @@ msgid "translation_to"
 msgstr "Käännös kielelle ${language}"
 
 #. Default: "Universal link"
-#: ../browser/menu.py:235
+#: ../browser/menu.py:237
 msgid "universal_link"
 msgstr "Kieliriippumaton linkki"
 

--- a/src/plone/app/multilingual/locales/fr/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/fr/LC_MESSAGES/plone.app.multilingual.po
@@ -2,9 +2,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.2b3\n"
-"POT-Creation-Date: 2017-07-13 21:35+0000\n"
-"PO-Revision-Date: 2015-09-16 01:58+0100\n"
-"Last-Translator: Encolpe DEGOUTE <encolpe.degoute@free.fr>\n"
+"POT-Creation-Date: 2018-03-19 06:49+0000\n"
+"PO-Revision-Date: 2018-03-19 07:54+0100\n"
+"Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: Plone-fr <plone-fr@lists.plone.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -15,26 +15,25 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: plone.app.multilingual\n"
 "Language: fr\n"
-"X-Generator: Poedit 1.7.5\n"
+"X-Generator: Poedit 1.8.7.1\n"
 
-#: ../browser/migrator.py:85
+#: ../browser/migrator.py:86
 msgid "After migration relation cleanup"
 msgstr "S'execute après la migration de nettoyage des relations"
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:60
 msgid "Cancel"
 msgstr ""
 
-#: ../browser/controlpanel.py:65
+#: ../browser/controlpanel.py:63
 msgid "Changes canceled."
 msgstr ""
 
-#: ../browser/templates/cleanup.pt:79
-#: ../browser/templates/migration.pt:250
+#: ../browser/templates/cleanup.pt:79 ../browser/templates/migration.pt:250
 msgid "Cleanup"
 msgstr "Nettoyage"
 
-#: ../browser/controlpanel.py:49
+#: ../browser/controlpanel.py:47
 msgid "Default language not in available languages"
 msgstr ""
 
@@ -46,7 +45,7 @@ msgstr "Cependant, il s'agit de la liste des langues déjà traduite pour l'él�
 msgid "Install to enable multilingual content support with plone.app.multilingual"
 msgstr ""
 
-#: ../browser/translate.py:69
+#: ../browser/translate.py:70
 msgid "Invalid field"
 msgstr "Champ invalide"
 
@@ -54,7 +53,7 @@ msgstr "Champ invalide"
 msgid "Language control panel"
 msgstr "Gestion des langues "
 
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Make this content type multilingual aware"
 msgstr ""
 
@@ -63,16 +62,15 @@ msgid "Move"
 msgstr "Déplacer"
 
 #. Default: "Multilingual"
-#: ../interfaces.py:183
+#: ../interfaces.py:184
 msgid "Multilingual"
 msgstr ""
 
-#: ../browser/controlpanel.py:32
+#: ../browser/controlpanel.py:30
 msgid "Multilingual Settings"
 msgstr "Options multilingues"
 
-#: ../configure.zcml:151
-#: ../dx/configure.zcml:36
+#: ../configure.zcml:151 ../dx/configure.zcml:37
 msgid "Multilingual Support"
 msgstr ""
 
@@ -80,11 +78,11 @@ msgstr ""
 msgid "Multilingual Support [uninstall]"
 msgstr ""
 
-#: ../browser/translate.py:54
+#: ../browser/translate.py:55
 msgid "Need a field"
 msgstr "Besoin d'un champ"
 
-#: ../browser/controlpanel.py:174
+#: ../browser/controlpanel.py:172
 msgid "Not translated"
 msgstr "Non traduit"
 
@@ -96,19 +94,19 @@ msgstr "Réindexer"
 msgid "Relocate"
 msgstr "Relocaliser"
 
-#: ../browser/migrator.py:127
+#: ../browser/migrator.py:128
 msgid "Relocate content to the proper root language folder"
 msgstr "Déplacer le contenu dans le bon dossier racine de langue"
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:36
 msgid "Save"
 msgstr ""
 
-#: ../interfaces.py:169
+#: ../interfaces.py:170
 msgid "Search for closest translation in parent's content chain."
 msgstr "Chercher la plus proche trad. dans la chaîne de contenu du parent."
 
-#: ../interfaces.py:172
+#: ../interfaces.py:173
 msgid "Show user dialog with information about the available translations."
 msgstr "Afficher un dialogue d'infos sur les trad. disponibles."
 
@@ -128,7 +126,7 @@ msgstr "Cet élément n'a aucune traduction pour le moment. Vous pouvez revenir 
 msgid "Transfer"
 msgstr "Transférer"
 
-#: ../browser/migrator.py:50
+#: ../browser/migrator.py:51
 msgid "Transfer multilingual catalog information"
 msgstr "Transférer l'information multilingue du catalogue"
 
@@ -140,23 +138,23 @@ msgstr ""
 msgid "Update bundle regristration"
 msgstr ""
 
-#. Default: "This object is going to be a translation to ${DYNAMIC_CONTENT} from: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "This object is going to be a translation to ${language} from:"
+#: ../browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
-msgstr "Cette élément est sur le point d'être traduit en ${DYNAMIC_CONTENT} à partir de : <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
+msgstr "Cette élément est sur le point d'être traduit en ${language} à partir de : "
 
 #. Default: "assets"
-#: ../browser/setup.py:139
+#: ../browser/setup.py:140
 msgid "assets_folder_id"
 msgstr ""
 
 #. Default: "Assets"
-#: ../browser/setup.py:142
+#: ../browser/setup.py:143
 msgid "assets_folder_title"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:44
+#: ../browser/modify.py:46
 msgid "connect_translation"
 msgstr ""
 
@@ -164,13 +162,13 @@ msgstr ""
 msgid "content"
 msgstr "Contenu"
 
-#. Default: "If you want to create this object without being a translation press <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">here</a>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "If you want to create this object without being a translation press ${url}"
+#: ../browser/templates/add-form-is-translation.pt:15
 msgid "create-object-without-translation"
-msgstr "Si vous souhaité créer cet élément sans rentrer dans le processus de traduction cliquez <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">ici</a>"
+msgstr "Si vous souhaité créer cet élément sans rentrer dans le processus de traduction cliquez ${url}"
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:161
+#: ../browser/menu.py:162
 msgid "create_translation"
 msgstr "Créer ${lang_name}"
 
@@ -180,33 +178,33 @@ msgid "description_after_migration_cleanup"
 msgstr "Cet migration fixera les dépendances perdues à l'interface ITranslatable cachée dans le catalogue des relations et les supprimera. Elle doit être executée seulement une fois que LinguaPlone a été complètement désinstallé."
 
 #. Default: "Edit {lang_name} with the two-column translation view"
-#: ../browser/menu.py:117
+#: ../browser/menu.py:118
 #, fuzzy
 msgid "description_babeledit_menu"
 msgstr "Modifier (Babel) ${lang_name}"
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
-#: ../interfaces.py:240
+#: ../interfaces.py:241
 msgid "description_buttons_babel_view_up_to_nr_translations"
 msgstr "Lorsqu'il y a plusieurs traductions pour un élément, le nombre de boutons affichés pour chaque sera trop large pour s'afficher dans le template. Choisissez ici à partir de combien d'élément il faut utiliser un de menu déroulant à la place des boutons. Zéro signifie que se sera tout le temps les boutons qui seront utilisés."
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
-#: ../interfaces.py:221
+#: ../interfaces.py:222
 msgid "description_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter using language the content on folder_contents"
-#: ../interfaces.py:198
+#: ../interfaces.py:199
 msgid "description_filter_content"
 msgstr "Filtrer le contenu de folder_contents en se basant sur la langue"
 
 #. Default: "Is a paying API in order to use google translation service"
-#: ../interfaces.py:256
+#: ../interfaces.py:257
 msgid "description_google_translation_key"
 msgstr "C'est une API payante pour utiliser le service de traduction de Google"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:466
+#: ../browser/menu.py:469
 msgid "description_language_folder"
 msgstr "Aller dans le dossier indiqué par la langue préférée du navigateur de l'utilisateur"
 
@@ -226,12 +224,12 @@ msgid "description_migration_results"
 msgstr "Vous verrez ici les résultats de la migration"
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:219
+#: ../browser/menu.py:220
 msgid "description_modify_translations"
 msgstr ""
 
 #. Default: "After creating a new translation redirecto to babel view"
-#: ../interfaces.py:209
+#: ../interfaces.py:210
 msgid "description_redirect_babel_view"
 msgstr "Après avoir créé une nouvelle traduction, rediriger vers la vue babel"
 
@@ -246,18 +244,18 @@ msgid "description_relocate_content"
 msgstr "Cet étape de migration déplacera le contenu dans le dossier racine du site correspondant à sa langue. En premier, il fera une recherche de contenu mal placé dans le site et déplacera dans le dossier parent traduit le plus prêt. Cette étape est destructive car elle modifie la structure arborescente de votre contenu. Assurez vous d'avoir correctement configuré les langues de votre site dans le panneau de configuration 'Langues' onglet 'Langues du site'."
 
 #. Default: "The default language used for the content and the UI of this site."
-#: ../interfaces.py:268
+#: ../interfaces.py:269
 msgid "description_selector_lookup_translations_policy"
 msgstr "La langue par défaut pour le contenu et les interfaces de ce site."
 
 #. Default: "Move the translation under another language folder"
-#: ../browser/menu.py:140
+#: ../browser/menu.py:141
 #, fuzzy
 msgid "description_set_language"
 msgstr "Préciser ou modifier la langue actuelle du contenu"
 
 #. Default: "Open the language independent assets folder"
-#: ../browser/menu.py:445
+#: ../browser/menu.py:448
 #, fuzzy
 msgid "description_shared_folder"
 msgstr "Afficher le dossier partagé (langue neutre)"
@@ -268,7 +266,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr "Cette étape transfèrera les relations entre les traductions stoquées par LinguaPlone dans le catalog de PAM. Cette étape n'est pas destructive est peut être executée autant que nécessaire."
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:166
+#: ../browser/menu.py:167
 msgid "description_translate_into"
 msgstr "Traduire en ${lang_name}"
 
@@ -278,7 +276,7 @@ msgid "description_translation_map"
 msgstr "Liste des traductions."
 
 #. Default: "Universal link to the content in user's preferred language"
-#: ../browser/menu.py:239
+#: ../browser/menu.py:241
 #, fuzzy
 msgid "description_universal_link"
 msgstr "Lien universel du contenu (langue automatique)"
@@ -289,22 +287,22 @@ msgid "description_update_language"
 msgstr "Langues non traduites pour ce contenu"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:112
+#: ../browser/menu.py:113
 msgid "edit_translation"
 msgstr "Modifier ${lang_name}"
 
 #. Default: "Folder's id is not a valid language code"
-#: ../browser/migrator.py:308
+#: ../browser/migrator.py:309
 msgid "folder_to_lrf_id_not_language"
 msgstr ""
 
 #. Default: "Only folders just below the root can be transformed"
-#: ../browser/migrator.py:297
+#: ../browser/migrator.py:298
 msgid "folder_to_lrf_not_next_to_root"
 msgstr ""
 
 #. Default: "Folder has been successfully transformed to a language root folder"
-#: ../browser/migrator.py:331
+#: ../browser/migrator.py:332
 msgid "folder_to_lrf_success"
 msgstr ""
 
@@ -314,22 +312,22 @@ msgid "heading_available_translations"
 msgstr "Langues disponibles pour ce contenu"
 
 #. Default: "Use buttons in the bable view for up to how many translations?"
-#: ../interfaces.py:236
+#: ../interfaces.py:237
 msgid "heading_buttons_babel_view_up_to_nr_translations"
 msgstr "Utilisez les boutons dans la vue babel pour combien de traductions ?"
 
 #. Default: "Bypass language independent field permission check"
-#: ../interfaces.py:218
+#: ../interfaces.py:219
 msgid "heading_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter content by language."
-#: ../interfaces.py:195
+#: ../interfaces.py:196
 msgid "heading_filter_content"
 msgstr "Filtrer le contenu par langue"
 
 #. Default: "Google Translation API Key"
-#: ../interfaces.py:253
+#: ../interfaces.py:254
 msgid "heading_google_translation_key"
 msgstr "Clé d'API de Google Translation"
 
@@ -354,12 +352,12 @@ msgid "heading_not_available_in_language"
 msgstr "Non disponible en ${language}"
 
 #. Default: "Redirect on creation to babel view."
-#: ../interfaces.py:206
+#: ../interfaces.py:207
 msgid "heading_redirect_babel_view"
 msgstr "Rediriger vers la vue babel après la création"
 
 #. Default: "The policy used to determine how the lookup for available translations will be made by the language selector."
-#: ../interfaces.py:264
+#: ../interfaces.py:265
 msgid "heading_selector_lookup_translations_policy"
 msgstr "Les règles utilisées pour déterminer comment la recherche de traductions sera faite par le sélecteur de langue."
 
@@ -372,6 +370,10 @@ msgstr "Carte de traduction plone.app.multilingual "
 #: ../browser/templates/migration.pt:118
 msgid "help_reindex_language_index"
 msgstr "La migration des contenus LinguaPlone dépend d'un index Language à jour. Utiliser cette étape pour rafraîchir cet index. Avertissement : En fonction du nombre d'éléments dans votre site cela peut durer un temps considérable."
+
+#: ../browser/templates/add-form-is-translation.pt:15
+msgid "here"
+msgstr "ici"
 
 #. Default: "All translations"
 #: ../browser/templates/mmap.pt:75
@@ -394,13 +396,12 @@ msgid "label_cleanup"
 msgstr "Actions de nettoyage"
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:37
+#: ../browser/modify.py:39
 msgid "label_connect_translation"
 msgstr ""
 
 #. Default: "General"
-#: ../browser/templates/cleanup.pt:38
-#: ../browser/templates/migration.pt:73
+#: ../browser/templates/cleanup.pt:38 ../browser/templates/migration.pt:73
 msgid "label_general"
 msgstr "Général"
 
@@ -436,13 +437,12 @@ msgid "label_total_relations"
 msgstr "Nombre total de relation mises à jour :"
 
 #. Default: "Translate"
-#: ../browser/menu.py:491
+#: ../browser/menu.py:494
 msgid "label_translate_menu"
 msgstr "Traduire"
 
 #. Default: "Translation Map"
-#: ../browser/templates/cleanup.pt:43
-#: ../browser/templates/migration.pt:78
+#: ../browser/templates/cleanup.pt:43 ../browser/templates/migration.pt:78
 msgid "label_translation_map"
 msgstr "Liste des traductions"
 
@@ -452,7 +452,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:462
+#: ../browser/menu.py:465
 msgid "language_folder"
 msgstr "Revenir au dossier de langue"
 
@@ -477,7 +477,7 @@ msgid "legend_transfer_multilingual_catalog_info"
 msgstr "Étape 2 - Transférer les informations du catalogue multilingual"
 
 #. Default: "This form allows you to connect a currently existing translations of the current object."
-#: ../browser/modify.py:38
+#: ../browser/modify.py:40
 msgid "long_description_connect_translation"
 msgstr ""
 
@@ -497,7 +497,7 @@ msgid "not_configured_for_multiple_languages"
 msgstr "Votre site n'est pas configuré avec plus d'une langue autorisée, mais l'extension fournissant le support pour des langues multiples est installée. Vous pouvez ajouter une ou plusieurs langues depuis ${control-panel-link}."
 
 #. Default: "All the configuration of a multilingual Plone site"
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid "pam_controlpanel_description"
 msgstr "Toute la configuration de plone.app.multilingual (PAM). Si vous voulez définir la langue par défaut ou déplacer le contenu racine dans le dossier de langue par défaut, allez dans la section Entretien du site."
 
@@ -512,7 +512,7 @@ msgid "relation_migration_with_not_needed"
 msgstr "Votre site n'a pas de catalogue de relations, et dans ce cas cette étape de migration n'est pas nécessaire"
 
 #. Default: "Open ${title} folder"
-#: ../browser/menu.py:440
+#: ../browser/menu.py:443
 #, fuzzy
 msgid "shared_folder"
 msgstr "Aller au dossier partagé"
@@ -528,28 +528,28 @@ msgid "title_language"
 msgstr "Langue"
 
 #. Default: "Manage translations"
-#: ../browser/menu.py:215
+#: ../browser/menu.py:216
 msgid "title_modify_translations"
 msgstr ""
 
 #. Default: "Change content language"
-#: ../browser/menu.py:136
+#: ../browser/menu.py:137
 #, fuzzy
 msgid "title_set_language"
 msgstr "Définir la langue du contenu"
 
 #. Default: "Folder translation"
-#: ../browser/menu.py:258
+#: ../browser/menu.py:260
 msgid "title_translate_current_folder"
 msgstr ""
 
 #. Default: "Item translation"
-#: ../browser/menu.py:422
+#: ../browser/menu.py:425
 msgid "title_translate_current_item"
 msgstr ""
 
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:492
+#: ../browser/menu.py:495
 msgid "title_translate_menu"
 msgstr "Gérer les traductions du contenu"
 
@@ -564,7 +564,7 @@ msgid "translation_to"
 msgstr "Traduire en ${language}"
 
 #. Default: "Universal link"
-#: ../browser/menu.py:235
+#: ../browser/menu.py:237
 #, fuzzy
 msgid "universal_link"
 msgstr "Lien universel"

--- a/src/plone/app/multilingual/locales/it/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/it/LC_MESSAGES/plone.app.multilingual.po
@@ -2,38 +2,39 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.2b3\n"
-"POT-Creation-Date: 2017-07-13 21:35+0000\n"
-"PO-Revision-Date: 2013-10-08 09:30+0000\n"
-"Last-Translator: Giorgio Borelli <giorgio@giorgioborelli.it>\n"
+"POT-Creation-Date: 2018-03-19 06:49+0000\n"
+"PO-Revision-Date: 2018-03-19 07:54+0100\n"
+"Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: Plone italian translation group <plone-italian-translation-discussion@lists.coactivate.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "Language-Code: it\n"
 "Language-Name: Italian\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: plone.app.multilingual\n"
 "X-Is-Fallback-For: it-ch it-it\n"
+"Language: it\n"
+"X-Generator: Poedit 1.8.7.1\n"
 
-#: ../browser/migrator.py:85
+#: ../browser/migrator.py:86
 msgid "After migration relation cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:60
 msgid "Cancel"
 msgstr ""
 
-#: ../browser/controlpanel.py:65
+#: ../browser/controlpanel.py:63
 msgid "Changes canceled."
 msgstr ""
 
-#: ../browser/templates/cleanup.pt:79
-#: ../browser/templates/migration.pt:250
+#: ../browser/templates/cleanup.pt:79 ../browser/templates/migration.pt:250
 msgid "Cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:49
+#: ../browser/controlpanel.py:47
 msgid "Default language not in available languages"
 msgstr ""
 
@@ -45,7 +46,7 @@ msgstr ""
 msgid "Install to enable multilingual content support with plone.app.multilingual"
 msgstr ""
 
-#: ../browser/translate.py:69
+#: ../browser/translate.py:70
 msgid "Invalid field"
 msgstr "Campo non valido"
 
@@ -53,7 +54,7 @@ msgstr "Campo non valido"
 msgid "Language control panel"
 msgstr "Pannello di controllo lingua"
 
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Make this content type multilingual aware"
 msgstr ""
 
@@ -62,16 +63,15 @@ msgid "Move"
 msgstr "Sposta"
 
 #. Default: "Multilingual"
-#: ../interfaces.py:183
+#: ../interfaces.py:184
 msgid "Multilingual"
 msgstr ""
 
-#: ../browser/controlpanel.py:32
+#: ../browser/controlpanel.py:30
 msgid "Multilingual Settings"
 msgstr "Impostazioni lingua"
 
-#: ../configure.zcml:151
-#: ../dx/configure.zcml:36
+#: ../configure.zcml:151 ../dx/configure.zcml:37
 msgid "Multilingual Support"
 msgstr ""
 
@@ -79,11 +79,11 @@ msgstr ""
 msgid "Multilingual Support [uninstall]"
 msgstr ""
 
-#: ../browser/translate.py:54
+#: ../browser/translate.py:55
 msgid "Need a field"
 msgstr ""
 
-#: ../browser/controlpanel.py:174
+#: ../browser/controlpanel.py:172
 msgid "Not translated"
 msgstr "Non tradotto"
 
@@ -95,19 +95,19 @@ msgstr "Re-indicizza"
 msgid "Relocate"
 msgstr ""
 
-#: ../browser/migrator.py:127
+#: ../browser/migrator.py:128
 msgid "Relocate content to the proper root language folder"
 msgstr ""
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:36
 msgid "Save"
 msgstr ""
 
-#: ../interfaces.py:169
+#: ../interfaces.py:170
 msgid "Search for closest translation in parent's content chain."
 msgstr "Cerca la traduzione più vicina nella catena dei genitori del contenuto"
 
-#: ../interfaces.py:172
+#: ../interfaces.py:173
 msgid "Show user dialog with information about the available translations."
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr "Questo elemenento non ha ancora alcuna traduzione. Puoi tornare alla hom
 msgid "Transfer"
 msgstr ""
 
-#: ../browser/migrator.py:50
+#: ../browser/migrator.py:51
 msgid "Transfer multilingual catalog information"
 msgstr ""
 
@@ -139,23 +139,23 @@ msgstr ""
 msgid "Update bundle regristration"
 msgstr ""
 
-#. Default: "This object is going to be a translation to ${DYNAMIC_CONTENT} from: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "This object is going to be a translation to ${language} from:"
+#: ../browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
-msgstr "Questo oggetto sta per diventare la traduzione di ${DYNAMIC_CONTENT} da: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
+msgstr "Questo oggetto sta per diventare la traduzione di ${language} da: "
 
 #. Default: "assets"
-#: ../browser/setup.py:139
+#: ../browser/setup.py:140
 msgid "assets_folder_id"
 msgstr ""
 
 #. Default: "Assets"
-#: ../browser/setup.py:142
+#: ../browser/setup.py:143
 msgid "assets_folder_title"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:44
+#: ../browser/modify.py:46
 msgid "connect_translation"
 msgstr ""
 
@@ -163,13 +163,13 @@ msgstr ""
 msgid "content"
 msgstr "Contenuto"
 
-#. Default: "If you want to create this object without being a translation press <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">here</a>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "If you want to create this object without being a translation press ${url}"
+#: ../browser/templates/add-form-is-translation.pt:15
 msgid "create-object-without-translation"
-msgstr "Se vuoi creare l'oggetto senza che sia la traduzione del contenuto originario clicca <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">qui</a>"
+msgstr "Se vuoi creare l'oggetto senza che sia la traduzione del contenuto originario clicca ${url}"
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:161
+#: ../browser/menu.py:162
 msgid "create_translation"
 msgstr "Crea ${lang_name}"
 
@@ -179,33 +179,33 @@ msgid "description_after_migration_cleanup"
 msgstr ""
 
 #. Default: "Edit {lang_name} with the two-column translation view"
-#: ../browser/menu.py:117
+#: ../browser/menu.py:118
 #, fuzzy
 msgid "description_babeledit_menu"
 msgstr "Babel edit ${lang_name}"
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
-#: ../interfaces.py:240
+#: ../interfaces.py:241
 msgid "description_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
-#: ../interfaces.py:221
+#: ../interfaces.py:222
 msgid "description_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter using language the content on folder_contents"
-#: ../interfaces.py:198
+#: ../interfaces.py:199
 msgid "description_filter_content"
 msgstr ""
 
 #. Default: "Is a paying API in order to use google translation service"
-#: ../interfaces.py:256
+#: ../interfaces.py:257
 msgid "description_google_translation_key"
 msgstr "Queste sono delle API a pagamento per utilizzare il servizio di traduzione di Google"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:466
+#: ../browser/menu.py:469
 msgid "description_language_folder"
 msgstr ""
 
@@ -225,12 +225,12 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:219
+#: ../browser/menu.py:220
 msgid "description_modify_translations"
 msgstr ""
 
 #. Default: "After creating a new translation redirecto to babel view"
-#: ../interfaces.py:209
+#: ../interfaces.py:210
 msgid "description_redirect_babel_view"
 msgstr "Dopo aver creato una nuova traduzione redirigi l'utente alla 'babel view'"
 
@@ -245,18 +245,18 @@ msgid "description_relocate_content"
 msgstr ""
 
 #. Default: "The default language used for the content and the UI of this site."
-#: ../interfaces.py:268
+#: ../interfaces.py:269
 msgid "description_selector_lookup_translations_policy"
 msgstr "La lingua di default usata per i contenuti e la UI del sito."
 
 #. Default: "Move the translation under another language folder"
-#: ../browser/menu.py:140
+#: ../browser/menu.py:141
 #, fuzzy
 msgid "description_set_language"
 msgstr "Imposta o cambia la lingua corrente di questo contenuto."
 
 #. Default: "Open the language independent assets folder"
-#: ../browser/menu.py:445
+#: ../browser/menu.py:448
 #, fuzzy
 msgid "description_shared_folder"
 msgstr "Visualizza la cartella condivisa tra le lingue (in lingua neutra)"
@@ -267,7 +267,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:166
+#: ../browser/menu.py:167
 msgid "description_translate_into"
 msgstr "Traduci in ${lang_name}"
 
@@ -277,7 +277,7 @@ msgid "description_translation_map"
 msgstr "Mappa traduzioni"
 
 #. Default: "Universal link to the content in user's preferred language"
-#: ../browser/menu.py:239
+#: ../browser/menu.py:241
 #, fuzzy
 msgid "description_universal_link"
 msgstr "Link universale indipendente dalla lingua"
@@ -288,22 +288,22 @@ msgid "description_update_language"
 msgstr "Lingue in cui il contenuto non è ancora stato tradotto"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:112
+#: ../browser/menu.py:113
 msgid "edit_translation"
 msgstr "Modifica ${lang_name}"
 
 #. Default: "Folder's id is not a valid language code"
-#: ../browser/migrator.py:308
+#: ../browser/migrator.py:309
 msgid "folder_to_lrf_id_not_language"
 msgstr ""
 
 #. Default: "Only folders just below the root can be transformed"
-#: ../browser/migrator.py:297
+#: ../browser/migrator.py:298
 msgid "folder_to_lrf_not_next_to_root"
 msgstr ""
 
 #. Default: "Folder has been successfully transformed to a language root folder"
-#: ../browser/migrator.py:331
+#: ../browser/migrator.py:332
 msgid "folder_to_lrf_success"
 msgstr ""
 
@@ -313,22 +313,22 @@ msgid "heading_available_translations"
 msgstr "Traduzioni disponibili per questo contenuto"
 
 #. Default: "Use buttons in the bable view for up to how many translations?"
-#: ../interfaces.py:236
+#: ../interfaces.py:237
 msgid "heading_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "Bypass language independent field permission check"
-#: ../interfaces.py:218
+#: ../interfaces.py:219
 msgid "heading_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter content by language."
-#: ../interfaces.py:195
+#: ../interfaces.py:196
 msgid "heading_filter_content"
 msgstr "Filtra i contenuti per lingua"
 
 #. Default: "Google Translation API Key"
-#: ../interfaces.py:253
+#: ../interfaces.py:254
 msgid "heading_google_translation_key"
 msgstr "Chiave API di Google Translation"
 
@@ -353,12 +353,12 @@ msgid "heading_not_available_in_language"
 msgstr "Non disponibile in ${language}"
 
 #. Default: "Redirect on creation to babel view."
-#: ../interfaces.py:206
+#: ../interfaces.py:207
 msgid "heading_redirect_babel_view"
 msgstr "Alla creazione usa la vista 'babel'"
 
 #. Default: "The policy used to determine how the lookup for available translations will be made by the language selector."
-#: ../interfaces.py:264
+#: ../interfaces.py:265
 msgid "heading_selector_lookup_translations_policy"
 msgstr ""
 
@@ -371,6 +371,10 @@ msgstr "Mappa delle traduzioni di plone.app.multilingua"
 #: ../browser/templates/migration.pt:118
 msgid "help_reindex_language_index"
 msgstr ""
+
+#: ../browser/templates/add-form-is-translation.pt:15
+msgid "here"
+msgstr "qui"
 
 #. Default: "All translations"
 #: ../browser/templates/mmap.pt:75
@@ -393,13 +397,12 @@ msgid "label_cleanup"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:37
+#: ../browser/modify.py:39
 msgid "label_connect_translation"
 msgstr ""
 
 #. Default: "General"
-#: ../browser/templates/cleanup.pt:38
-#: ../browser/templates/migration.pt:73
+#: ../browser/templates/cleanup.pt:38 ../browser/templates/migration.pt:73
 msgid "label_general"
 msgstr "Generale"
 
@@ -435,13 +438,12 @@ msgid "label_total_relations"
 msgstr "Numero di relazioni interessate:"
 
 #. Default: "Translate"
-#: ../browser/menu.py:491
+#: ../browser/menu.py:494
 msgid "label_translate_menu"
 msgstr "Traduci"
 
 #. Default: "Translation Map"
-#: ../browser/templates/cleanup.pt:43
-#: ../browser/templates/migration.pt:78
+#: ../browser/templates/cleanup.pt:43 ../browser/templates/migration.pt:78
 msgid "label_translation_map"
 msgstr "Mappa traduzioni"
 
@@ -451,7 +453,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:462
+#: ../browser/menu.py:465
 msgid "language_folder"
 msgstr "Ritorna alla cartella lingua"
 
@@ -476,7 +478,7 @@ msgid "legend_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "This form allows you to connect a currently existing translations of the current object."
-#: ../browser/modify.py:38
+#: ../browser/modify.py:40
 msgid "long_description_connect_translation"
 msgstr ""
 
@@ -496,7 +498,7 @@ msgid "not_configured_for_multiple_languages"
 msgstr ""
 
 #. Default: "All the configuration of a multilingual Plone site"
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid "pam_controlpanel_description"
 msgstr ""
 
@@ -511,7 +513,7 @@ msgid "relation_migration_with_not_needed"
 msgstr ""
 
 #. Default: "Open ${title} folder"
-#: ../browser/menu.py:440
+#: ../browser/menu.py:443
 #, fuzzy
 msgid "shared_folder"
 msgstr "Vai alla cartella condivisa"
@@ -527,28 +529,28 @@ msgid "title_language"
 msgstr "Lingue"
 
 #. Default: "Manage translations"
-#: ../browser/menu.py:215
+#: ../browser/menu.py:216
 msgid "title_modify_translations"
 msgstr ""
 
 #. Default: "Change content language"
-#: ../browser/menu.py:136
+#: ../browser/menu.py:137
 #, fuzzy
 msgid "title_set_language"
 msgstr "Imposta la lingua del contenuto"
 
 #. Default: "Folder translation"
-#: ../browser/menu.py:258
+#: ../browser/menu.py:260
 msgid "title_translate_current_folder"
 msgstr ""
 
 #. Default: "Item translation"
-#: ../browser/menu.py:422
+#: ../browser/menu.py:425
 msgid "title_translate_current_item"
 msgstr ""
 
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:492
+#: ../browser/menu.py:495
 msgid "title_translate_menu"
 msgstr "Gestisci le traduzioni del contenuto"
 
@@ -563,7 +565,7 @@ msgid "translation_to"
 msgstr "Traduci in ${language}"
 
 #. Default: "Universal link"
-#: ../browser/menu.py:235
+#: ../browser/menu.py:237
 #, fuzzy
 msgid "universal_link"
 msgstr "Link universale"

--- a/src/plone/app/multilingual/locales/ja/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/ja/LC_MESSAGES/plone.app.multilingual.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.2b3\n"
-"POT-Creation-Date: 2017-07-13 21:35+0000\n"
+"POT-Creation-Date: 2018-03-19 06:49+0000\n"
 "PO-Revision-Date: 2015-04-29 14:51+0900\n"
 "Last-Translator: Manabu TERADA <terada@cmscom.jp>\n"
 "Language-Team: Plone Japanese Team <https://github.com/plonejp>\n"
@@ -16,15 +16,15 @@ msgstr ""
 "Preferred-Encodings: utf-8\n"
 "Domain: plone.app.multilingual\n"
 
-#: ../browser/migrator.py:85
+#: ../browser/migrator.py:86
 msgid "After migration relation cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:60
 msgid "Cancel"
 msgstr ""
 
-#: ../browser/controlpanel.py:65
+#: ../browser/controlpanel.py:63
 msgid "Changes canceled."
 msgstr ""
 
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Cleanup"
 msgstr "クリーンアップ"
 
-#: ../browser/controlpanel.py:49
+#: ../browser/controlpanel.py:47
 msgid "Default language not in available languages"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Install to enable multilingual content support with plone.app.multilingual"
 msgstr ""
 
-#: ../browser/translate.py:69
+#: ../browser/translate.py:70
 msgid "Invalid field"
 msgstr ""
 
@@ -53,7 +53,7 @@ msgstr ""
 msgid "Language control panel"
 msgstr ""
 
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Make this content type multilingual aware"
 msgstr ""
 
@@ -62,16 +62,16 @@ msgid "Move"
 msgstr ""
 
 #. Default: "Multilingual"
-#: ../interfaces.py:183
+#: ../interfaces.py:184
 msgid "Multilingual"
 msgstr ""
 
-#: ../browser/controlpanel.py:32
+#: ../browser/controlpanel.py:30
 msgid "Multilingual Settings"
 msgstr "多言語設定"
 
 #: ../configure.zcml:151
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Multilingual Support"
 msgstr ""
 
@@ -79,11 +79,11 @@ msgstr ""
 msgid "Multilingual Support [uninstall]"
 msgstr ""
 
-#: ../browser/translate.py:54
+#: ../browser/translate.py:55
 msgid "Need a field"
 msgstr ""
 
-#: ../browser/controlpanel.py:174
+#: ../browser/controlpanel.py:172
 msgid "Not translated"
 msgstr ""
 
@@ -95,19 +95,19 @@ msgstr ""
 msgid "Relocate"
 msgstr ""
 
-#: ../browser/migrator.py:127
+#: ../browser/migrator.py:128
 msgid "Relocate content to the proper root language folder"
 msgstr ""
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:36
 msgid "Save"
 msgstr ""
 
-#: ../interfaces.py:169
+#: ../interfaces.py:170
 msgid "Search for closest translation in parent's content chain."
 msgstr ""
 
-#: ../interfaces.py:172
+#: ../interfaces.py:173
 msgid "Show user dialog with information about the available translations."
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Transfer"
 msgstr ""
 
-#: ../browser/migrator.py:50
+#: ../browser/migrator.py:51
 msgid "Transfer multilingual catalog information"
 msgstr ""
 
@@ -139,23 +139,23 @@ msgstr ""
 msgid "Update bundle regristration"
 msgstr ""
 
-#. Default: "This object is going to be a translation to ${DYNAMIC_CONTENT} from: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "This object is going to be a translation to ${language} from:"
+#: ../browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
 msgstr ""
 
 #. Default: "assets"
-#: ../browser/setup.py:139
+#: ../browser/setup.py:140
 msgid "assets_folder_id"
 msgstr ""
 
 #. Default: "Assets"
-#: ../browser/setup.py:142
+#: ../browser/setup.py:143
 msgid "assets_folder_title"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:44
+#: ../browser/modify.py:46
 msgid "connect_translation"
 msgstr ""
 
@@ -163,13 +163,13 @@ msgstr ""
 msgid "content"
 msgstr "コンテンツ"
 
-#. Default: "If you want to create this object without being a translation press <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">here</a>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "If you want to create this object without being a translation press ${url}"
+#: ../browser/templates/add-form-is-translation.pt:15
 msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:161
+#: ../browser/menu.py:162
 msgid "create_translation"
 msgstr ""
 
@@ -179,32 +179,32 @@ msgid "description_after_migration_cleanup"
 msgstr ""
 
 #. Default: "Edit {lang_name} with the two-column translation view"
-#: ../browser/menu.py:117
+#: ../browser/menu.py:118
 msgid "description_babeledit_menu"
 msgstr ""
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
-#: ../interfaces.py:240
+#: ../interfaces.py:241
 msgid "description_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
-#: ../interfaces.py:221
+#: ../interfaces.py:222
 msgid "description_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter using language the content on folder_contents"
-#: ../interfaces.py:198
+#: ../interfaces.py:199
 msgid "description_filter_content"
 msgstr ""
 
 #. Default: "Is a paying API in order to use google translation service"
-#: ../interfaces.py:256
+#: ../interfaces.py:257
 msgid "description_google_translation_key"
 msgstr ""
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:466
+#: ../browser/menu.py:469
 msgid "description_language_folder"
 msgstr ""
 
@@ -224,12 +224,12 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:219
+#: ../browser/menu.py:220
 msgid "description_modify_translations"
 msgstr ""
 
 #. Default: "After creating a new translation redirecto to babel view"
-#: ../interfaces.py:209
+#: ../interfaces.py:210
 msgid "description_redirect_babel_view"
 msgstr ""
 
@@ -244,17 +244,17 @@ msgid "description_relocate_content"
 msgstr ""
 
 #. Default: "The default language used for the content and the UI of this site."
-#: ../interfaces.py:268
+#: ../interfaces.py:269
 msgid "description_selector_lookup_translations_policy"
 msgstr ""
 
 #. Default: "Move the translation under another language folder"
-#: ../browser/menu.py:140
+#: ../browser/menu.py:141
 msgid "description_set_language"
 msgstr ""
 
 #. Default: "Open the language independent assets folder"
-#: ../browser/menu.py:445
+#: ../browser/menu.py:448
 msgid "description_shared_folder"
 msgstr ""
 
@@ -264,7 +264,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:166
+#: ../browser/menu.py:167
 msgid "description_translate_into"
 msgstr "${lang_name}に翻訳"
 
@@ -274,7 +274,7 @@ msgid "description_translation_map"
 msgstr ""
 
 #. Default: "Universal link to the content in user's preferred language"
-#: ../browser/menu.py:239
+#: ../browser/menu.py:241
 msgid "description_universal_link"
 msgstr ""
 
@@ -284,22 +284,22 @@ msgid "description_update_language"
 msgstr ""
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:112
+#: ../browser/menu.py:113
 msgid "edit_translation"
 msgstr ""
 
 #. Default: "Folder's id is not a valid language code"
-#: ../browser/migrator.py:308
+#: ../browser/migrator.py:309
 msgid "folder_to_lrf_id_not_language"
 msgstr ""
 
 #. Default: "Only folders just below the root can be transformed"
-#: ../browser/migrator.py:297
+#: ../browser/migrator.py:298
 msgid "folder_to_lrf_not_next_to_root"
 msgstr ""
 
 #. Default: "Folder has been successfully transformed to a language root folder"
-#: ../browser/migrator.py:331
+#: ../browser/migrator.py:332
 msgid "folder_to_lrf_success"
 msgstr ""
 
@@ -309,22 +309,22 @@ msgid "heading_available_translations"
 msgstr ""
 
 #. Default: "Use buttons in the bable view for up to how many translations?"
-#: ../interfaces.py:236
+#: ../interfaces.py:237
 msgid "heading_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "Bypass language independent field permission check"
-#: ../interfaces.py:218
+#: ../interfaces.py:219
 msgid "heading_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter content by language."
-#: ../interfaces.py:195
+#: ../interfaces.py:196
 msgid "heading_filter_content"
 msgstr ""
 
 #. Default: "Google Translation API Key"
-#: ../interfaces.py:253
+#: ../interfaces.py:254
 msgid "heading_google_translation_key"
 msgstr ""
 
@@ -349,12 +349,12 @@ msgid "heading_not_available_in_language"
 msgstr ""
 
 #. Default: "Redirect on creation to babel view."
-#: ../interfaces.py:206
+#: ../interfaces.py:207
 msgid "heading_redirect_babel_view"
 msgstr ""
 
 #. Default: "The policy used to determine how the lookup for available translations will be made by the language selector."
-#: ../interfaces.py:264
+#: ../interfaces.py:265
 msgid "heading_selector_lookup_translations_policy"
 msgstr ""
 
@@ -366,6 +366,10 @@ msgstr ""
 #. Default: "The migration of LinguaPlone content depends on an up-to-date Language index. Use this step to refresh this index. Warning: Depending on the number of items in your site, this can take a considerable amount of time."
 #: ../browser/templates/migration.pt:118
 msgid "help_reindex_language_index"
+msgstr ""
+
+#: ../browser/templates/add-form-is-translation.pt:15
+msgid "here"
 msgstr ""
 
 #. Default: "All translations"
@@ -389,7 +393,7 @@ msgid "label_cleanup"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:37
+#: ../browser/modify.py:39
 msgid "label_connect_translation"
 msgstr ""
 
@@ -431,7 +435,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:491
+#: ../browser/menu.py:494
 #, fuzzy
 msgid "label_translate_menu"
 msgstr "翻訳する"
@@ -448,7 +452,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:462
+#: ../browser/menu.py:465
 msgid "language_folder"
 msgstr ""
 
@@ -473,7 +477,7 @@ msgid "legend_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "This form allows you to connect a currently existing translations of the current object."
-#: ../browser/modify.py:38
+#: ../browser/modify.py:40
 msgid "long_description_connect_translation"
 msgstr ""
 
@@ -493,7 +497,7 @@ msgid "not_configured_for_multiple_languages"
 msgstr ""
 
 #. Default: "All the configuration of a multilingual Plone site"
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid "pam_controlpanel_description"
 msgstr "Ploneサイトのすべての多言語設定"
 
@@ -508,7 +512,7 @@ msgid "relation_migration_with_not_needed"
 msgstr ""
 
 #. Default: "Open ${title} folder"
-#: ../browser/menu.py:440
+#: ../browser/menu.py:443
 msgid "shared_folder"
 msgstr ""
 
@@ -523,27 +527,27 @@ msgid "title_language"
 msgstr "言語"
 
 #. Default: "Manage translations"
-#: ../browser/menu.py:215
+#: ../browser/menu.py:216
 msgid "title_modify_translations"
 msgstr ""
 
 #. Default: "Change content language"
-#: ../browser/menu.py:136
+#: ../browser/menu.py:137
 msgid "title_set_language"
 msgstr ""
 
 #. Default: "Folder translation"
-#: ../browser/menu.py:258
+#: ../browser/menu.py:260
 msgid "title_translate_current_folder"
 msgstr ""
 
 #. Default: "Item translation"
-#: ../browser/menu.py:422
+#: ../browser/menu.py:425
 msgid "title_translate_current_item"
 msgstr ""
 
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:492
+#: ../browser/menu.py:495
 msgid "title_translate_menu"
 msgstr "コンテンツの翻訳を管理"
 
@@ -558,7 +562,7 @@ msgid "translation_to"
 msgstr ""
 
 #. Default: "Universal link"
-#: ../browser/menu.py:235
+#: ../browser/menu.py:237
 msgid "universal_link"
 msgstr ""
 

--- a/src/plone/app/multilingual/locales/nl/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/nl/LC_MESSAGES/plone.app.multilingual.po
@@ -1,9 +1,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone.app.multilingual\n"
-"POT-Creation-Date: 2017-07-13 21:35+0000\n"
-"PO-Revision-Date: 2017-02-28 10:22+0100\n"
-"Last-Translator: Jean-Paul Ladage <j.ladage@zestsoftware.nl>\n"
+"POT-Creation-Date: 2018-03-19 06:49+0000\n"
+"PO-Revision-Date: 2018-03-19 07:51+0100\n"
+"Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: Nederlands <translators@plone.nl>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -14,26 +14,25 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: plone.app.multilingual\n"
 "Language: nl\n"
-"X-Generator: Poedit 1.8.12\n"
+"X-Generator: Poedit 1.8.7.1\n"
 
-#: ../browser/migrator.py:85
+#: ../browser/migrator.py:86
 msgid "After migration relation cleanup"
 msgstr "Opschonen na migatie "
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:60
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: ../browser/controlpanel.py:65
+#: ../browser/controlpanel.py:63
 msgid "Changes canceled."
 msgstr "Wijzigingen annuleren"
 
-#: ../browser/templates/cleanup.pt:79
-#: ../browser/templates/migration.pt:250
+#: ../browser/templates/cleanup.pt:79 ../browser/templates/migration.pt:250
 msgid "Cleanup"
 msgstr "Opschonen"
 
-#: ../browser/controlpanel.py:49
+#: ../browser/controlpanel.py:47
 msgid "Default language not in available languages"
 msgstr "Standaardtaal niet gesteld in beschikbare talen"
 
@@ -45,7 +44,7 @@ msgstr "Hoewel, dit is de lijst met overige vertalingen."
 msgid "Install to enable multilingual content support with plone.app.multilingual"
 msgstr "Installeren om meertaligheid in te schakelen"
 
-#: ../browser/translate.py:69
+#: ../browser/translate.py:70
 msgid "Invalid field"
 msgstr "Ongeldig veld"
 
@@ -53,7 +52,7 @@ msgstr "Ongeldig veld"
 msgid "Language control panel"
 msgstr "Taalinstellingen"
 
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Make this content type multilingual aware"
 msgstr "Maak dit content type meertalig"
 
@@ -62,16 +61,15 @@ msgid "Move"
 msgstr "Verplaatsen"
 
 #. Default: "Multilingual"
-#: ../interfaces.py:183
+#: ../interfaces.py:184
 msgid "Multilingual"
 msgstr "Meertaligheid"
 
-#: ../browser/controlpanel.py:32
+#: ../browser/controlpanel.py:30
 msgid "Multilingual Settings"
 msgstr "Meertaligheid instelling"
 
-#: ../configure.zcml:151
-#: ../dx/configure.zcml:36
+#: ../configure.zcml:151 ../dx/configure.zcml:37
 msgid "Multilingual Support"
 msgstr ""
 
@@ -79,11 +77,11 @@ msgstr ""
 msgid "Multilingual Support [uninstall]"
 msgstr ""
 
-#: ../browser/translate.py:54
+#: ../browser/translate.py:55
 msgid "Need a field"
 msgstr "Een veld nodig"
 
-#: ../browser/controlpanel.py:174
+#: ../browser/controlpanel.py:172
 msgid "Not translated"
 msgstr "Niet vertaald"
 
@@ -95,19 +93,19 @@ msgstr "Herindexeren"
 msgid "Relocate"
 msgstr "Verplaatsen"
 
-#: ../browser/migrator.py:127
+#: ../browser/migrator.py:128
 msgid "Relocate content to the proper root language folder"
 msgstr "Verplaats content naar de juiste taalmap."
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:36
 msgid "Save"
 msgstr "Opslaan"
 
-#: ../interfaces.py:169
+#: ../interfaces.py:170
 msgid "Search for closest translation in parent's content chain."
 msgstr "Zoek naar vertaling in de bovenliggende map"
 
-#: ../interfaces.py:172
+#: ../interfaces.py:173
 msgid "Show user dialog with information about the available translations."
 msgstr "Toon venster met informatie over beschikbare vertalingen"
 
@@ -127,7 +125,7 @@ msgstr "Dit item heeft nog geen vertaling. U kunt terug naar de site:"
 msgid "Transfer"
 msgstr "Omzetten"
 
-#: ../browser/migrator.py:50
+#: ../browser/migrator.py:51
 msgid "Transfer multilingual catalog information"
 msgstr "Meertaligheidsinformatie overnemen"
 
@@ -139,23 +137,23 @@ msgstr "Deactiveren, verwijderd meertaligheid."
 msgid "Update bundle regristration"
 msgstr "Bundel registratie bijwerken."
 
-#. Default: "This object is going to be a translation to ${DYNAMIC_CONTENT} from: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "This object is going to be a translation to ${language} from:"
+#: ../browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
-msgstr "Dit wordt een vertaling naar ${DYNAMIC_CONTENT} van <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
+msgstr "Dit wordt een vertaling naar ${language} van:"
 
 #. Default: "assets"
-#: ../browser/setup.py:139
+#: ../browser/setup.py:140
 msgid "assets_folder_id"
 msgstr ""
 
 #. Default: "Assets"
-#: ../browser/setup.py:142
+#: ../browser/setup.py:143
 msgid "assets_folder_title"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:44
+#: ../browser/modify.py:46
 msgid "connect_translation"
 msgstr "Vertaling koppelen"
 
@@ -163,13 +161,14 @@ msgstr "Vertaling koppelen"
 msgid "content"
 msgstr "Inhoud"
 
-#. Default: "If you want to create this object without being a translation press <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">here</a>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "If you want to create this object without being a translation press ${url}"
+#: ../browser/templates/add-form-is-translation.pt:15
+#, fuzzy
 msgid "create-object-without-translation"
 msgstr "Als u dit item wilt aanmaken zonder vertaling <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">klik hier</a>"
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:161
+#: ../browser/menu.py:162
 msgid "create_translation"
 msgstr "${lang_name} aanmaken"
 
@@ -179,33 +178,33 @@ msgid "description_after_migration_cleanup"
 msgstr "Deze stap wil hersteld enkele vertalingen en schoont de catalogus op. Alleen uitvoeren als LinguaPlone al actief is"
 
 #. Default: "Edit {lang_name} with the two-column translation view"
-#: ../browser/menu.py:117
+#: ../browser/menu.py:118
 #, fuzzy
 msgid "description_babeledit_menu"
 msgstr "${lang_name} bewerken met Babel"
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
-#: ../interfaces.py:240
+#: ../interfaces.py:241
 msgid "description_buttons_babel_view_up_to_nr_translations"
 msgstr "Als er veel talen voor een item zijn, passen de button wellicht niet binnen het ontwerp. Kies hier vanaf welk aantal de talen in een dropdown getoond moeten worden"
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
-#: ../interfaces.py:221
+#: ../interfaces.py:222
 msgid "description_bypass_languageindependent_field_permission_check"
 msgstr "Indien u een item met een taalonafhankelijk veld opslaat wordt de waarde van dat veld overgenomen in de vertaalde versies. Dit zou fout kunnen geven als de gebruiker geen rechten heeft op de vertalingen. Schakel deze optie in om deze fouten te negeren en de waarde te overschrijven."
 
 #. Default: "Filter using language the content on folder_contents"
-#: ../interfaces.py:198
+#: ../interfaces.py:199
 msgid "description_filter_content"
 msgstr "Filter op taal bij Inhoud"
 
 #. Default: "Is a paying API in order to use google translation service"
-#: ../interfaces.py:256
+#: ../interfaces.py:257
 msgid "description_google_translation_key"
 msgstr "Google Translation API Key"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:466
+#: ../browser/menu.py:469
 msgid "description_language_folder"
 msgstr "Ga terug naar de taalafhankelijke map"
 
@@ -225,12 +224,12 @@ msgid "description_migration_results"
 msgstr "Hier ziet u de resultaten van het migratieproces."
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:219
+#: ../browser/menu.py:220
 msgid "description_modify_translations"
 msgstr "Vertalingen toevoegen of verwijderen"
 
 #. Default: "After creating a new translation redirecto to babel view"
-#: ../interfaces.py:209
+#: ../interfaces.py:210
 msgid "description_redirect_babel_view"
 msgstr "Na het aanmaken van een vertaling de Babel weergave tonen"
 
@@ -245,18 +244,18 @@ msgid "description_relocate_content"
 msgstr "Deze stap zal de inhoud verplaatsen naar de overeenkomstige talen waarmogelijk. Indien de taal niet duidelijk is, wordt deze zo veel mogelijk één-op-één overgenomen. Controleer of alle beschikbare talen zijn ingesteld via website-instellingen > Taal"
 
 #. Default: "The default language used for the content and the UI of this site."
-#: ../interfaces.py:268
+#: ../interfaces.py:269
 msgid "description_selector_lookup_translations_policy"
 msgstr "De standaardtaal wordt gebruikt voor de inhoud en de UI van deze site."
 
 #. Default: "Move the translation under another language folder"
-#: ../browser/menu.py:140
+#: ../browser/menu.py:141
 #, fuzzy
 msgid "description_set_language"
 msgstr "Huidige taal instellen of wijzigen"
 
 #. Default: "Open the language independent assets folder"
-#: ../browser/menu.py:445
+#: ../browser/menu.py:448
 #, fuzzy
 msgid "description_shared_folder"
 msgstr "Toon de gedeelde taalonafhankelijke map"
@@ -267,7 +266,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr "Deze stap de relaties tussen vertalingen overzetten naar de PAM catalogus. Deze stap breekt niets en kan meerdere keren uitgevoerd worden."
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:166
+#: ../browser/menu.py:167
 msgid "description_translate_into"
 msgstr "Vertaal naar ${lang_name}"
 
@@ -277,7 +276,7 @@ msgid "description_translation_map"
 msgstr "Vertaaloverzicht"
 
 #. Default: "Universal link to the content in user's preferred language"
-#: ../browser/menu.py:239
+#: ../browser/menu.py:241
 #, fuzzy
 msgid "description_universal_link"
 msgstr "Universele taal link"
@@ -288,22 +287,22 @@ msgid "description_update_language"
 msgstr "Ontbrekende vertalingen voor dit item"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:112
+#: ../browser/menu.py:113
 msgid "edit_translation"
 msgstr "${lang_name} bewerken"
 
 #. Default: "Folder's id is not a valid language code"
-#: ../browser/migrator.py:308
+#: ../browser/migrator.py:309
 msgid "folder_to_lrf_id_not_language"
 msgstr "De id van de map is geen geldige taalcode (bijv. en of nl)"
 
 #. Default: "Only folders just below the root can be transformed"
-#: ../browser/migrator.py:297
+#: ../browser/migrator.py:298
 msgid "folder_to_lrf_not_next_to_root"
 msgstr "Alleen mappen in de root van de site kunnen als taalmap ingesteld worden."
 
 #. Default: "Folder has been successfully transformed to a language root folder"
-#: ../browser/migrator.py:331
+#: ../browser/migrator.py:332
 msgid "folder_to_lrf_success"
 msgstr "Deze map is nu omgezet naar een taalmap."
 
@@ -313,22 +312,22 @@ msgid "heading_available_translations"
 msgstr "Beschikbare vertalingen voor deze inhoud"
 
 #. Default: "Use buttons in the bable view for up to how many translations?"
-#: ../interfaces.py:236
+#: ../interfaces.py:237
 msgid "heading_buttons_babel_view_up_to_nr_translations"
 msgstr "Gebruik knoppen in de taalkiezer tot het onderstaande aantal, toon daarboven een dropdown."
 
 #. Default: "Bypass language independent field permission check"
-#: ../interfaces.py:218
+#: ../interfaces.py:219
 msgid "heading_bypass_languageindependent_field_permission_check"
 msgstr "Rechten niet controleren voor taalonhankelijke velden."
 
 #. Default: "Filter content by language."
-#: ../interfaces.py:195
+#: ../interfaces.py:196
 msgid "heading_filter_content"
 msgstr "Filter inhoud op taal"
 
 #. Default: "Google Translation API Key"
-#: ../interfaces.py:253
+#: ../interfaces.py:254
 msgid "heading_google_translation_key"
 msgstr "Google Translation API Key"
 
@@ -353,12 +352,12 @@ msgid "heading_not_available_in_language"
 msgstr "Niet beschikbaar in ${language}"
 
 #. Default: "Redirect on creation to babel view."
-#: ../interfaces.py:206
+#: ../interfaces.py:207
 msgid "heading_redirect_babel_view"
 msgstr "Naar babelweergave na aanmaken"
 
 #. Default: "The policy used to determine how the lookup for available translations will be made by the language selector."
-#: ../interfaces.py:264
+#: ../interfaces.py:265
 msgid "heading_selector_lookup_translations_policy"
 msgstr "Het beleid dat bepaald welke beschikbare taal gebruikt wordt in de taalkiezer."
 
@@ -371,6 +370,10 @@ msgstr "Meertaligheidsoverzicht"
 #: ../browser/templates/migration.pt:118
 msgid "help_reindex_language_index"
 msgstr "De migratie van LinguaPlone verwacht dat de taal index up-to-date is. Afhankelijk van de hoeveelheid content kan dit lang duren."
+
+#: ../browser/templates/add-form-is-translation.pt:15
+msgid "here"
+msgstr ""
 
 #. Default: "All translations"
 #: ../browser/templates/mmap.pt:75
@@ -393,13 +396,12 @@ msgid "label_cleanup"
 msgstr "Opschoon-acties"
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:37
+#: ../browser/modify.py:39
 msgid "label_connect_translation"
 msgstr "Vertaling koppelen"
 
 #. Default: "General"
-#: ../browser/templates/cleanup.pt:38
-#: ../browser/templates/migration.pt:73
+#: ../browser/templates/cleanup.pt:38 ../browser/templates/migration.pt:73
 msgid "label_general"
 msgstr "Algemeen"
 
@@ -435,13 +437,12 @@ msgid "label_total_relations"
 msgstr "Aantal aangepaste koppelingen"
 
 #. Default: "Translate"
-#: ../browser/menu.py:491
+#: ../browser/menu.py:494
 msgid "label_translate_menu"
 msgstr "Vertalen"
 
 #. Default: "Translation Map"
-#: ../browser/templates/cleanup.pt:43
-#: ../browser/templates/migration.pt:78
+#: ../browser/templates/cleanup.pt:43 ../browser/templates/migration.pt:78
 msgid "label_translation_map"
 msgstr "Vertalingsoverzicht"
 
@@ -451,7 +452,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:462
+#: ../browser/menu.py:465
 msgid "language_folder"
 msgstr "Terug naar taalmap"
 
@@ -476,7 +477,7 @@ msgid "legend_transfer_multilingual_catalog_info"
 msgstr "Stap 2 - Meertaligsheidsinformatie overnemen"
 
 #. Default: "This form allows you to connect a currently existing translations of the current object."
-#: ../browser/modify.py:38
+#: ../browser/modify.py:40
 msgid "long_description_connect_translation"
 msgstr "Dit formulier stel u in staat om reeds bestaand vertalingen te koppelen aan dit item."
 
@@ -496,7 +497,7 @@ msgid "not_configured_for_multiple_languages"
 msgstr "Uw website heeft maar een beschikbare taal ingesteld, maar deze meertaligheids module verwacht meerdere talen. Voeg extra talen toe via ${control-panel-link}</a> "
 
 #. Default: "All the configuration of a multilingual Plone site"
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid "pam_controlpanel_description"
 msgstr "Alle instellingen van een meertalige website"
 
@@ -511,7 +512,7 @@ msgid "relation_migration_with_not_needed"
 msgstr "Uw website heeft geen relatie catalogus, deze migratie-stap in niet nodig."
 
 #. Default: "Open ${title} folder"
-#: ../browser/menu.py:440
+#: ../browser/menu.py:443
 #, fuzzy
 msgid "shared_folder"
 msgstr "Ga naar Media map"
@@ -527,29 +528,29 @@ msgid "title_language"
 msgstr "Taal"
 
 #. Default: "Manage translations"
-#: ../browser/menu.py:215
+#: ../browser/menu.py:216
 #, fuzzy
 msgid "title_modify_translations"
 msgstr "Vertalingen aanpassen"
 
 #. Default: "Change content language"
-#: ../browser/menu.py:136
+#: ../browser/menu.py:137
 #, fuzzy
 msgid "title_set_language"
 msgstr "Taal instellen"
 
 #. Default: "Folder translation"
-#: ../browser/menu.py:258
+#: ../browser/menu.py:260
 msgid "title_translate_current_folder"
 msgstr ""
 
 #. Default: "Item translation"
-#: ../browser/menu.py:422
+#: ../browser/menu.py:425
 msgid "title_translate_current_item"
 msgstr ""
 
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:492
+#: ../browser/menu.py:495
 msgid "title_translate_menu"
 msgstr "Talen beheren voor uw inhoud"
 
@@ -564,7 +565,7 @@ msgid "translation_to"
 msgstr "Vertaling naar ${language}"
 
 #. Default: "Universal link"
-#: ../browser/menu.py:235
+#: ../browser/menu.py:237
 #, fuzzy
 msgid "universal_link"
 msgstr "Universele link"

--- a/src/plone/app/multilingual/locales/pl/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/pl/LC_MESSAGES/plone.app.multilingual.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone.app.multilingual\n"
-"POT-Creation-Date: 2017-07-13 21:35+0000\n"
+"POT-Creation-Date: 2018-03-19 06:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Radek Jankiewicz <radoslaw.jankiewicz@gmail.com>\n"
 "Language-Team: plone-cat <plone-cat@plone.org>\n"
@@ -14,15 +14,15 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin2\n"
 "Domain: plone.app.multilingual\n"
 
-#: ../browser/migrator.py:85
+#: ../browser/migrator.py:86
 msgid "After migration relation cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:60
 msgid "Cancel"
 msgstr ""
 
-#: ../browser/controlpanel.py:65
+#: ../browser/controlpanel.py:63
 msgid "Changes canceled."
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr ""
 msgid "Cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:49
+#: ../browser/controlpanel.py:47
 msgid "Default language not in available languages"
 msgstr ""
 
@@ -43,7 +43,7 @@ msgstr "Lista języków na które został przetłumaczony wybrany obiekt"
 msgid "Install to enable multilingual content support with plone.app.multilingual"
 msgstr ""
 
-#: ../browser/translate.py:69
+#: ../browser/translate.py:70
 msgid "Invalid field"
 msgstr "Nieprawidłowe pole"
 
@@ -51,7 +51,7 @@ msgstr "Nieprawidłowe pole"
 msgid "Language control panel"
 msgstr ""
 
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Make this content type multilingual aware"
 msgstr ""
 
@@ -60,16 +60,16 @@ msgid "Move"
 msgstr ""
 
 #. Default: "Multilingual"
-#: ../interfaces.py:183
+#: ../interfaces.py:184
 msgid "Multilingual"
 msgstr ""
 
-#: ../browser/controlpanel.py:32
+#: ../browser/controlpanel.py:30
 msgid "Multilingual Settings"
 msgstr "Ustawienia wersji językowych"
 
 #: ../configure.zcml:151
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Multilingual Support"
 msgstr ""
 
@@ -77,11 +77,11 @@ msgstr ""
 msgid "Multilingual Support [uninstall]"
 msgstr ""
 
-#: ../browser/translate.py:54
+#: ../browser/translate.py:55
 msgid "Need a field"
 msgstr "Wymagane jest podanie pola"
 
-#: ../browser/controlpanel.py:174
+#: ../browser/controlpanel.py:172
 msgid "Not translated"
 msgstr "Nie przetłumaczone"
 
@@ -93,19 +93,19 @@ msgstr ""
 msgid "Relocate"
 msgstr ""
 
-#: ../browser/migrator.py:127
+#: ../browser/migrator.py:128
 msgid "Relocate content to the proper root language folder"
 msgstr ""
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:36
 msgid "Save"
 msgstr ""
 
-#: ../interfaces.py:169
+#: ../interfaces.py:170
 msgid "Search for closest translation in parent's content chain."
 msgstr "Wyszukaj najbliższego przetłumaczonego obiektu wśród obiektów nadrzędnych"
 
-#: ../interfaces.py:172
+#: ../interfaces.py:173
 msgid "Show user dialog with information about the available translations."
 msgstr "Wyświetlaj informację o możliwych tłumaczeniach"
 
@@ -125,7 +125,7 @@ msgstr ""
 msgid "Transfer"
 msgstr ""
 
-#: ../browser/migrator.py:50
+#: ../browser/migrator.py:51
 msgid "Transfer multilingual catalog information"
 msgstr ""
 
@@ -137,23 +137,23 @@ msgstr ""
 msgid "Update bundle regristration"
 msgstr ""
 
-#. Default: "This object is going to be a translation to ${DYNAMIC_CONTENT} from: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "This object is going to be a translation to ${language} from:"
+#: ../browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
 msgstr ""
 
 #. Default: "assets"
-#: ../browser/setup.py:139
+#: ../browser/setup.py:140
 msgid "assets_folder_id"
 msgstr ""
 
 #. Default: "Assets"
-#: ../browser/setup.py:142
+#: ../browser/setup.py:143
 msgid "assets_folder_title"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:44
+#: ../browser/modify.py:46
 msgid "connect_translation"
 msgstr ""
 
@@ -161,13 +161,13 @@ msgstr ""
 msgid "content"
 msgstr "treść"
 
-#. Default: "If you want to create this object without being a translation press <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">here</a>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "If you want to create this object without being a translation press ${url}"
+#: ../browser/templates/add-form-is-translation.pt:15
 msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:161
+#: ../browser/menu.py:162
 msgid "create_translation"
 msgstr ""
 
@@ -177,33 +177,33 @@ msgid "description_after_migration_cleanup"
 msgstr ""
 
 #. Default: "Edit {lang_name} with the two-column translation view"
-#: ../browser/menu.py:117
+#: ../browser/menu.py:118
 #, fuzzy
 msgid "description_babeledit_menu"
 msgstr "Edytuj przy użyciu 'Babel': ${lang_name}"
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
-#: ../interfaces.py:240
+#: ../interfaces.py:241
 msgid "description_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
-#: ../interfaces.py:221
+#: ../interfaces.py:222
 msgid "description_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter using language the content on folder_contents"
-#: ../interfaces.py:198
+#: ../interfaces.py:199
 msgid "description_filter_content"
 msgstr "Filtruj treść po wersji językowej w listingu zawartości folderu"
 
 #. Default: "Is a paying API in order to use google translation service"
-#: ../interfaces.py:256
+#: ../interfaces.py:257
 msgid "description_google_translation_key"
 msgstr "Klucz API do serwisu Google Translation"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:466
+#: ../browser/menu.py:469
 msgid "description_language_folder"
 msgstr "Przejdź do folderu zgodnego z ustawieniami językowymi przeglądarki użytkownika"
 
@@ -224,12 +224,12 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:219
+#: ../browser/menu.py:220
 msgid "description_modify_translations"
 msgstr ""
 
 #. Default: "After creating a new translation redirecto to babel view"
-#: ../interfaces.py:209
+#: ../interfaces.py:210
 msgid "description_redirect_babel_view"
 msgstr "Po utworzeniu nowej wersji językowej przekieruj do widoku Babel"
 
@@ -244,18 +244,18 @@ msgid "description_relocate_content"
 msgstr ""
 
 #. Default: "The default language used for the content and the UI of this site."
-#: ../interfaces.py:268
+#: ../interfaces.py:269
 msgid "description_selector_lookup_translations_policy"
 msgstr "Domyślny język, w którym tworzona jest treść i wyświetlany jest interfejs użytkownika."
 
 #. Default: "Move the translation under another language folder"
-#: ../browser/menu.py:140
+#: ../browser/menu.py:141
 #, fuzzy
 msgid "description_set_language"
 msgstr "Ustaw lub zmień obecny język treści"
 
 #. Default: "Open the language independent assets folder"
-#: ../browser/menu.py:445
+#: ../browser/menu.py:448
 #, fuzzy
 msgid "description_shared_folder"
 msgstr "Wyświetlaj folder zawierający treść w języku neutralnym"
@@ -266,7 +266,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:166
+#: ../browser/menu.py:167
 msgid "description_translate_into"
 msgstr "Przetłumacz na ${lang_name}"
 
@@ -276,7 +276,7 @@ msgid "description_translation_map"
 msgstr "Mapa tłumaczeń."
 
 #. Default: "Universal link to the content in user's preferred language"
-#: ../browser/menu.py:239
+#: ../browser/menu.py:241
 #, fuzzy
 msgid "description_universal_link"
 msgstr "Uniwersalny link do danego obiektu, wyświetlający jego wersję językową zgodną z ustawiwniami językowymi przeglądadki użytkownika"
@@ -287,22 +287,22 @@ msgid "description_update_language"
 msgstr "Nieprzetłumaczone języki dla tego obiektu"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:112
+#: ../browser/menu.py:113
 msgid "edit_translation"
 msgstr ""
 
 #. Default: "Folder's id is not a valid language code"
-#: ../browser/migrator.py:308
+#: ../browser/migrator.py:309
 msgid "folder_to_lrf_id_not_language"
 msgstr ""
 
 #. Default: "Only folders just below the root can be transformed"
-#: ../browser/migrator.py:297
+#: ../browser/migrator.py:298
 msgid "folder_to_lrf_not_next_to_root"
 msgstr ""
 
 #. Default: "Folder has been successfully transformed to a language root folder"
-#: ../browser/migrator.py:331
+#: ../browser/migrator.py:332
 msgid "folder_to_lrf_success"
 msgstr ""
 
@@ -312,22 +312,22 @@ msgid "heading_available_translations"
 msgstr "Dostępne wersje językowe dla tego obiektu"
 
 #. Default: "Use buttons in the bable view for up to how many translations?"
-#: ../interfaces.py:236
+#: ../interfaces.py:237
 msgid "heading_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "Bypass language independent field permission check"
-#: ../interfaces.py:218
+#: ../interfaces.py:219
 msgid "heading_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter content by language."
-#: ../interfaces.py:195
+#: ../interfaces.py:196
 msgid "heading_filter_content"
 msgstr "Filtruj treść przy pomocy języka."
 
 #. Default: "Google Translation API Key"
-#: ../interfaces.py:253
+#: ../interfaces.py:254
 msgid "heading_google_translation_key"
 msgstr "Klucz API do serwisu Google Translation"
 
@@ -352,12 +352,12 @@ msgid "heading_not_available_in_language"
 msgstr ""
 
 #. Default: "Redirect on creation to babel view."
-#: ../interfaces.py:206
+#: ../interfaces.py:207
 msgid "heading_redirect_babel_view"
 msgstr "Przejdź do widoku Babel po utworzeniu obiektu."
 
 #. Default: "The policy used to determine how the lookup for available translations will be made by the language selector."
-#: ../interfaces.py:264
+#: ../interfaces.py:265
 msgid "heading_selector_lookup_translations_policy"
 msgstr "Zasady używane do ustalenia w jaki sposób bedą pobierane istniejące wersje językowe do zmiany języka"
 
@@ -369,6 +369,10 @@ msgstr "Mapa wersji językowych"
 #. Default: "The migration of LinguaPlone content depends on an up-to-date Language index. Use this step to refresh this index. Warning: Depending on the number of items in your site, this can take a considerable amount of time."
 #: ../browser/templates/migration.pt:118
 msgid "help_reindex_language_index"
+msgstr ""
+
+#: ../browser/templates/add-form-is-translation.pt:15
+msgid "here"
 msgstr ""
 
 #. Default: "All translations"
@@ -392,7 +396,7 @@ msgid "label_cleanup"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:37
+#: ../browser/modify.py:39
 msgid "label_connect_translation"
 msgstr ""
 
@@ -434,7 +438,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:491
+#: ../browser/menu.py:494
 msgid "label_translate_menu"
 msgstr "Tłumacz"
 
@@ -450,7 +454,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:462
+#: ../browser/menu.py:465
 msgid "language_folder"
 msgstr "Wróć do folderu języka"
 
@@ -475,7 +479,7 @@ msgid "legend_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "This form allows you to connect a currently existing translations of the current object."
-#: ../browser/modify.py:38
+#: ../browser/modify.py:40
 msgid "long_description_connect_translation"
 msgstr ""
 
@@ -495,7 +499,7 @@ msgid "not_configured_for_multiple_languages"
 msgstr ""
 
 #. Default: "All the configuration of a multilingual Plone site"
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid "pam_controlpanel_description"
 msgstr "Panel konfiguracyjny dla ustawień wersji językowych. Jeśli chcesz ustawić domyślny język dla wszystkich obiektów bez ustawionego języka i przenieść treść do folderu domyślnego języka - przejdź do sekcji Dodatkowych opcji "
 
@@ -510,7 +514,7 @@ msgid "relation_migration_with_not_needed"
 msgstr ""
 
 #. Default: "Open ${title} folder"
-#: ../browser/menu.py:440
+#: ../browser/menu.py:443
 #, fuzzy
 msgid "shared_folder"
 msgstr "Przejdź do folderu współdzielonego"
@@ -526,28 +530,28 @@ msgid "title_language"
 msgstr "Język"
 
 #. Default: "Manage translations"
-#: ../browser/menu.py:215
+#: ../browser/menu.py:216
 msgid "title_modify_translations"
 msgstr ""
 
 #. Default: "Change content language"
-#: ../browser/menu.py:136
+#: ../browser/menu.py:137
 #, fuzzy
 msgid "title_set_language"
 msgstr "Ustaw język treści"
 
 #. Default: "Folder translation"
-#: ../browser/menu.py:258
+#: ../browser/menu.py:260
 msgid "title_translate_current_folder"
 msgstr ""
 
 #. Default: "Item translation"
-#: ../browser/menu.py:422
+#: ../browser/menu.py:425
 msgid "title_translate_current_item"
 msgstr ""
 
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:492
+#: ../browser/menu.py:495
 msgid "title_translate_menu"
 msgstr "Zarządzaj tłumaczeniami obiektu"
 
@@ -562,7 +566,7 @@ msgid "translation_to"
 msgstr "Tłumaczenie na ${language}"
 
 #. Default: "Universal link"
-#: ../browser/menu.py:235
+#: ../browser/menu.py:237
 #, fuzzy
 msgid "universal_link"
 msgstr "Link uniwersalny"

--- a/src/plone/app/multilingual/locales/plone.app.multilingual.pot
+++ b/src/plone/app/multilingual/locales/plone.app.multilingual.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-07-13 21:35+0000\n"
+"POT-Creation-Date: 2018-03-19 06:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,15 +17,15 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: plone.app.multilingual\n"
 
-#: ../browser/migrator.py:85
+#: ../browser/migrator.py:86
 msgid "After migration relation cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:60
 msgid "Cancel"
 msgstr ""
 
-#: ../browser/controlpanel.py:65
+#: ../browser/controlpanel.py:63
 msgid "Changes canceled."
 msgstr ""
 
@@ -34,7 +34,7 @@ msgstr ""
 msgid "Cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:49
+#: ../browser/controlpanel.py:47
 msgid "Default language not in available languages"
 msgstr ""
 
@@ -46,7 +46,7 @@ msgstr ""
 msgid "Install to enable multilingual content support with plone.app.multilingual"
 msgstr ""
 
-#: ../browser/translate.py:69
+#: ../browser/translate.py:70
 msgid "Invalid field"
 msgstr ""
 
@@ -54,7 +54,7 @@ msgstr ""
 msgid "Language control panel"
 msgstr ""
 
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Make this content type multilingual aware"
 msgstr ""
 
@@ -63,16 +63,16 @@ msgid "Move"
 msgstr ""
 
 #. Default: "Multilingual"
-#: ../interfaces.py:183
+#: ../interfaces.py:184
 msgid "Multilingual"
 msgstr ""
 
-#: ../browser/controlpanel.py:32
+#: ../browser/controlpanel.py:30
 msgid "Multilingual Settings"
 msgstr ""
 
 #: ../configure.zcml:151
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Multilingual Support"
 msgstr ""
 
@@ -80,11 +80,11 @@ msgstr ""
 msgid "Multilingual Support [uninstall]"
 msgstr ""
 
-#: ../browser/translate.py:54
+#: ../browser/translate.py:55
 msgid "Need a field"
 msgstr ""
 
-#: ../browser/controlpanel.py:174
+#: ../browser/controlpanel.py:172
 msgid "Not translated"
 msgstr ""
 
@@ -96,19 +96,19 @@ msgstr ""
 msgid "Relocate"
 msgstr ""
 
-#: ../browser/migrator.py:127
+#: ../browser/migrator.py:128
 msgid "Relocate content to the proper root language folder"
 msgstr ""
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:36
 msgid "Save"
 msgstr ""
 
-#: ../interfaces.py:169
+#: ../interfaces.py:170
 msgid "Search for closest translation in parent's content chain."
 msgstr ""
 
-#: ../interfaces.py:172
+#: ../interfaces.py:173
 msgid "Show user dialog with information about the available translations."
 msgstr ""
 
@@ -128,7 +128,7 @@ msgstr ""
 msgid "Transfer"
 msgstr ""
 
-#: ../browser/migrator.py:50
+#: ../browser/migrator.py:51
 msgid "Transfer multilingual catalog information"
 msgstr ""
 
@@ -140,23 +140,23 @@ msgstr ""
 msgid "Update bundle regristration"
 msgstr ""
 
-#. Default: "This object is going to be a translation to ${DYNAMIC_CONTENT} from: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "This object is going to be a translation to ${language} from:"
+#: ../browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
 msgstr ""
 
 #. Default: "assets"
-#: ../browser/setup.py:139
+#: ../browser/setup.py:140
 msgid "assets_folder_id"
 msgstr ""
 
 #. Default: "Assets"
-#: ../browser/setup.py:142
+#: ../browser/setup.py:143
 msgid "assets_folder_title"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:44
+#: ../browser/modify.py:46
 msgid "connect_translation"
 msgstr ""
 
@@ -164,13 +164,13 @@ msgstr ""
 msgid "content"
 msgstr ""
 
-#. Default: "If you want to create this object without being a translation press <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">here</a>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "If you want to create this object without being a translation press ${url}"
+#: ../browser/templates/add-form-is-translation.pt:15
 msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:161
+#: ../browser/menu.py:162
 msgid "create_translation"
 msgstr ""
 
@@ -180,32 +180,32 @@ msgid "description_after_migration_cleanup"
 msgstr ""
 
 #. Default: "Edit {lang_name} with the two-column translation view"
-#: ../browser/menu.py:117
+#: ../browser/menu.py:118
 msgid "description_babeledit_menu"
 msgstr ""
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
-#: ../interfaces.py:240
+#: ../interfaces.py:241
 msgid "description_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
-#: ../interfaces.py:221
+#: ../interfaces.py:222
 msgid "description_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter using language the content on folder_contents"
-#: ../interfaces.py:198
+#: ../interfaces.py:199
 msgid "description_filter_content"
 msgstr ""
 
 #. Default: "Is a paying API in order to use google translation service"
-#: ../interfaces.py:256
+#: ../interfaces.py:257
 msgid "description_google_translation_key"
 msgstr ""
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:466
+#: ../browser/menu.py:469
 msgid "description_language_folder"
 msgstr ""
 
@@ -225,12 +225,12 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:219
+#: ../browser/menu.py:220
 msgid "description_modify_translations"
 msgstr ""
 
 #. Default: "After creating a new translation redirecto to babel view"
-#: ../interfaces.py:209
+#: ../interfaces.py:210
 msgid "description_redirect_babel_view"
 msgstr ""
 
@@ -245,17 +245,17 @@ msgid "description_relocate_content"
 msgstr ""
 
 #. Default: "The default language used for the content and the UI of this site."
-#: ../interfaces.py:268
+#: ../interfaces.py:269
 msgid "description_selector_lookup_translations_policy"
 msgstr ""
 
 #. Default: "Move the translation under another language folder"
-#: ../browser/menu.py:140
+#: ../browser/menu.py:141
 msgid "description_set_language"
 msgstr ""
 
 #. Default: "Open the language independent assets folder"
-#: ../browser/menu.py:445
+#: ../browser/menu.py:448
 msgid "description_shared_folder"
 msgstr ""
 
@@ -265,7 +265,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:166
+#: ../browser/menu.py:167
 msgid "description_translate_into"
 msgstr ""
 
@@ -275,7 +275,7 @@ msgid "description_translation_map"
 msgstr ""
 
 #. Default: "Universal link to the content in user's preferred language"
-#: ../browser/menu.py:239
+#: ../browser/menu.py:241
 msgid "description_universal_link"
 msgstr ""
 
@@ -285,22 +285,22 @@ msgid "description_update_language"
 msgstr ""
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:112
+#: ../browser/menu.py:113
 msgid "edit_translation"
 msgstr ""
 
 #. Default: "Folder's id is not a valid language code"
-#: ../browser/migrator.py:308
+#: ../browser/migrator.py:309
 msgid "folder_to_lrf_id_not_language"
 msgstr ""
 
 #. Default: "Only folders just below the root can be transformed"
-#: ../browser/migrator.py:297
+#: ../browser/migrator.py:298
 msgid "folder_to_lrf_not_next_to_root"
 msgstr ""
 
 #. Default: "Folder has been successfully transformed to a language root folder"
-#: ../browser/migrator.py:331
+#: ../browser/migrator.py:332
 msgid "folder_to_lrf_success"
 msgstr ""
 
@@ -310,22 +310,22 @@ msgid "heading_available_translations"
 msgstr ""
 
 #. Default: "Use buttons in the bable view for up to how many translations?"
-#: ../interfaces.py:236
+#: ../interfaces.py:237
 msgid "heading_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "Bypass language independent field permission check"
-#: ../interfaces.py:218
+#: ../interfaces.py:219
 msgid "heading_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter content by language."
-#: ../interfaces.py:195
+#: ../interfaces.py:196
 msgid "heading_filter_content"
 msgstr ""
 
 #. Default: "Google Translation API Key"
-#: ../interfaces.py:253
+#: ../interfaces.py:254
 msgid "heading_google_translation_key"
 msgstr ""
 
@@ -350,12 +350,12 @@ msgid "heading_not_available_in_language"
 msgstr ""
 
 #. Default: "Redirect on creation to babel view."
-#: ../interfaces.py:206
+#: ../interfaces.py:207
 msgid "heading_redirect_babel_view"
 msgstr ""
 
 #. Default: "The policy used to determine how the lookup for available translations will be made by the language selector."
-#: ../interfaces.py:264
+#: ../interfaces.py:265
 msgid "heading_selector_lookup_translations_policy"
 msgstr ""
 
@@ -367,6 +367,10 @@ msgstr ""
 #. Default: "The migration of LinguaPlone content depends on an up-to-date Language index. Use this step to refresh this index. Warning: Depending on the number of items in your site, this can take a considerable amount of time."
 #: ../browser/templates/migration.pt:118
 msgid "help_reindex_language_index"
+msgstr ""
+
+#: ../browser/templates/add-form-is-translation.pt:15
+msgid "here"
 msgstr ""
 
 #. Default: "All translations"
@@ -390,7 +394,7 @@ msgid "label_cleanup"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:37
+#: ../browser/modify.py:39
 msgid "label_connect_translation"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:491
+#: ../browser/menu.py:494
 msgid "label_translate_menu"
 msgstr ""
 
@@ -448,7 +452,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:462
+#: ../browser/menu.py:465
 msgid "language_folder"
 msgstr ""
 
@@ -473,7 +477,7 @@ msgid "legend_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "This form allows you to connect a currently existing translations of the current object."
-#: ../browser/modify.py:38
+#: ../browser/modify.py:40
 msgid "long_description_connect_translation"
 msgstr ""
 
@@ -493,7 +497,7 @@ msgid "not_configured_for_multiple_languages"
 msgstr ""
 
 #. Default: "All the configuration of a multilingual Plone site"
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid "pam_controlpanel_description"
 msgstr ""
 
@@ -508,7 +512,7 @@ msgid "relation_migration_with_not_needed"
 msgstr ""
 
 #. Default: "Open ${title} folder"
-#: ../browser/menu.py:440
+#: ../browser/menu.py:443
 msgid "shared_folder"
 msgstr ""
 
@@ -523,27 +527,27 @@ msgid "title_language"
 msgstr ""
 
 #. Default: "Manage translations"
-#: ../browser/menu.py:215
+#: ../browser/menu.py:216
 msgid "title_modify_translations"
 msgstr ""
 
 #. Default: "Change content language"
-#: ../browser/menu.py:136
+#: ../browser/menu.py:137
 msgid "title_set_language"
 msgstr ""
 
 #. Default: "Folder translation"
-#: ../browser/menu.py:258
+#: ../browser/menu.py:260
 msgid "title_translate_current_folder"
 msgstr ""
 
 #. Default: "Item translation"
-#: ../browser/menu.py:422
+#: ../browser/menu.py:425
 msgid "title_translate_current_item"
 msgstr ""
 
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:492
+#: ../browser/menu.py:495
 msgid "title_translate_menu"
 msgstr ""
 
@@ -558,7 +562,7 @@ msgid "translation_to"
 msgstr ""
 
 #. Default: "Universal link"
-#: ../browser/menu.py:235
+#: ../browser/menu.py:237
 msgid "universal_link"
 msgstr ""
 

--- a/src/plone/app/multilingual/locales/sk/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/sk/LC_MESSAGES/plone.app.multilingual.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone.app.multilingual\n"
-"POT-Creation-Date: 2017-07-13 21:35+0000\n"
+"POT-Creation-Date: 2018-03-19 06:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Radek Jankiewicz <backup.rlacko@gmail.com>\n"
 "Language-Team: plone-cat <plone-cat@plone.org>\n"
@@ -14,15 +14,15 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin2\n"
 "Domain: plone.app.multilingual\n"
 
-#: ../browser/migrator.py:85
+#: ../browser/migrator.py:86
 msgid "After migration relation cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:60
 msgid "Cancel"
 msgstr ""
 
-#: ../browser/controlpanel.py:65
+#: ../browser/controlpanel.py:63
 msgid "Changes canceled."
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr ""
 msgid "Cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:49
+#: ../browser/controlpanel.py:47
 msgid "Default language not in available languages"
 msgstr ""
 
@@ -43,7 +43,7 @@ msgstr "Zoznam jazykov, ktoré boli preložené pre vybraný objekt"
 msgid "Install to enable multilingual content support with plone.app.multilingual"
 msgstr ""
 
-#: ../browser/translate.py:69
+#: ../browser/translate.py:70
 msgid "Invalid field"
 msgstr "Nesprávne pole"
 
@@ -51,7 +51,7 @@ msgstr "Nesprávne pole"
 msgid "Language control panel"
 msgstr ""
 
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Make this content type multilingual aware"
 msgstr ""
 
@@ -60,16 +60,16 @@ msgid "Move"
 msgstr ""
 
 #. Default: "Multilingual"
-#: ../interfaces.py:183
+#: ../interfaces.py:184
 msgid "Multilingual"
 msgstr ""
 
-#: ../browser/controlpanel.py:32
+#: ../browser/controlpanel.py:30
 msgid "Multilingual Settings"
 msgstr "Nastavenie jazykov"
 
 #: ../configure.zcml:151
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Multilingual Support"
 msgstr ""
 
@@ -77,11 +77,11 @@ msgstr ""
 msgid "Multilingual Support [uninstall]"
 msgstr ""
 
-#: ../browser/translate.py:54
+#: ../browser/translate.py:55
 msgid "Need a field"
 msgstr "Je vyžadované pole"
 
-#: ../browser/controlpanel.py:174
+#: ../browser/controlpanel.py:172
 msgid "Not translated"
 msgstr "Nepreložené"
 
@@ -93,19 +93,19 @@ msgstr ""
 msgid "Relocate"
 msgstr ""
 
-#: ../browser/migrator.py:127
+#: ../browser/migrator.py:128
 msgid "Relocate content to the proper root language folder"
 msgstr ""
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:36
 msgid "Save"
 msgstr ""
 
-#: ../interfaces.py:169
+#: ../interfaces.py:170
 msgid "Search for closest translation in parent's content chain."
 msgstr "Hľadať najbližší preklad v rodičovských objektoch"
 
-#: ../interfaces.py:172
+#: ../interfaces.py:173
 msgid "Show user dialog with information about the available translations."
 msgstr "Zobraziť okno s informáciou o dostupných prekladoch"
 
@@ -125,7 +125,7 @@ msgstr ""
 msgid "Transfer"
 msgstr ""
 
-#: ../browser/migrator.py:50
+#: ../browser/migrator.py:51
 msgid "Transfer multilingual catalog information"
 msgstr ""
 
@@ -137,23 +137,23 @@ msgstr ""
 msgid "Update bundle regristration"
 msgstr ""
 
-#. Default: "This object is going to be a translation to ${DYNAMIC_CONTENT} from: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "This object is going to be a translation to ${language} from:"
+#: ../browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
 msgstr ""
 
 #. Default: "assets"
-#: ../browser/setup.py:139
+#: ../browser/setup.py:140
 msgid "assets_folder_id"
 msgstr ""
 
 #. Default: "Assets"
-#: ../browser/setup.py:142
+#: ../browser/setup.py:143
 msgid "assets_folder_title"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:44
+#: ../browser/modify.py:46
 msgid "connect_translation"
 msgstr ""
 
@@ -161,13 +161,13 @@ msgstr ""
 msgid "content"
 msgstr "obsah"
 
-#. Default: "If you want to create this object without being a translation press <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">here</a>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "If you want to create this object without being a translation press ${url}"
+#: ../browser/templates/add-form-is-translation.pt:15
 msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:161
+#: ../browser/menu.py:162
 msgid "create_translation"
 msgstr ""
 
@@ -177,33 +177,33 @@ msgid "description_after_migration_cleanup"
 msgstr ""
 
 #. Default: "Edit {lang_name} with the two-column translation view"
-#: ../browser/menu.py:117
+#: ../browser/menu.py:118
 #, fuzzy
 msgid "description_babeledit_menu"
 msgstr "Upraviť pomocou editora 'Babel': ${lang_name}"
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
-#: ../interfaces.py:240
+#: ../interfaces.py:241
 msgid "description_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
-#: ../interfaces.py:221
+#: ../interfaces.py:222
 msgid "description_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter using language the content on folder_contents"
-#: ../interfaces.py:198
+#: ../interfaces.py:199
 msgid "description_filter_content"
 msgstr "Filtrovať obsah podľa verzie jazyka v obsahu zložky"
 
 #. Default: "Is a paying API in order to use google translation service"
-#: ../interfaces.py:256
+#: ../interfaces.py:257
 msgid "description_google_translation_key"
 msgstr "API kľúč pre Google Translation servis"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:466
+#: ../browser/menu.py:469
 msgid "description_language_folder"
 msgstr "Choďte do zložky podľa nastavenia jazyka v prehliadači užívateľa"
 
@@ -224,12 +224,12 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:219
+#: ../browser/menu.py:220
 msgid "description_modify_translations"
 msgstr ""
 
 #. Default: "After creating a new translation redirecto to babel view"
-#: ../interfaces.py:209
+#: ../interfaces.py:210
 msgid "description_redirect_babel_view"
 msgstr "Po vytvorení nového prekladu presmerovať do zobrazenia Babel"
 
@@ -244,18 +244,18 @@ msgid "description_relocate_content"
 msgstr ""
 
 #. Default: "The default language used for the content and the UI of this site."
-#: ../interfaces.py:268
+#: ../interfaces.py:269
 msgid "description_selector_lookup_translations_policy"
 msgstr "Predvolený jazyk, v ktorom je vytvorený obsah, a užívateľské rozhranie."
 
 #. Default: "Move the translation under another language folder"
-#: ../browser/menu.py:140
+#: ../browser/menu.py:141
 #, fuzzy
 msgid "description_set_language"
 msgstr "Nastavenie alebo zmena aktuálneho jazyka obsahu"
 
 #. Default: "Open the language independent assets folder"
-#: ../browser/menu.py:445
+#: ../browser/menu.py:448
 #, fuzzy
 msgid "description_shared_folder"
 msgstr "Zobraziť priečinok s obsahom v neutrálnom jazyku"
@@ -266,7 +266,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:166
+#: ../browser/menu.py:167
 msgid "description_translate_into"
 msgstr "Preložiť do ${lang_name}"
 
@@ -276,7 +276,7 @@ msgid "description_translation_map"
 msgstr "Mapa prekladu."
 
 #. Default: "Universal link to the content in user's preferred language"
-#: ../browser/menu.py:239
+#: ../browser/menu.py:241
 #, fuzzy
 msgid "description_universal_link"
 msgstr "Odkaz na obsah v univerzálnom preklade"
@@ -287,22 +287,22 @@ msgid "description_update_language"
 msgstr "Nepreložené jazyky pre tento objekt"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:112
+#: ../browser/menu.py:113
 msgid "edit_translation"
 msgstr ""
 
 #. Default: "Folder's id is not a valid language code"
-#: ../browser/migrator.py:308
+#: ../browser/migrator.py:309
 msgid "folder_to_lrf_id_not_language"
 msgstr ""
 
 #. Default: "Only folders just below the root can be transformed"
-#: ../browser/migrator.py:297
+#: ../browser/migrator.py:298
 msgid "folder_to_lrf_not_next_to_root"
 msgstr ""
 
 #. Default: "Folder has been successfully transformed to a language root folder"
-#: ../browser/migrator.py:331
+#: ../browser/migrator.py:332
 msgid "folder_to_lrf_success"
 msgstr ""
 
@@ -312,22 +312,22 @@ msgid "heading_available_translations"
 msgstr "Dostupné preklady pre tento objekt"
 
 #. Default: "Use buttons in the bable view for up to how many translations?"
-#: ../interfaces.py:236
+#: ../interfaces.py:237
 msgid "heading_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "Bypass language independent field permission check"
-#: ../interfaces.py:218
+#: ../interfaces.py:219
 msgid "heading_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter content by language."
-#: ../interfaces.py:195
+#: ../interfaces.py:196
 msgid "heading_filter_content"
 msgstr "Filtrovať obsah podľa jazyka."
 
 #. Default: "Google Translation API Key"
-#: ../interfaces.py:253
+#: ../interfaces.py:254
 msgid "heading_google_translation_key"
 msgstr "API kľúč pre Google Translation servis"
 
@@ -352,12 +352,12 @@ msgid "heading_not_available_in_language"
 msgstr ""
 
 #. Default: "Redirect on creation to babel view."
-#: ../interfaces.py:206
+#: ../interfaces.py:207
 msgid "heading_redirect_babel_view"
 msgstr "Po vytvorení objektu presunúť do zobrazenia Babel."
 
 #. Default: "The policy used to determine how the lookup for available translations will be made by the language selector."
-#: ../interfaces.py:264
+#: ../interfaces.py:265
 msgid "heading_selector_lookup_translations_policy"
 msgstr "Pravidlá vyhľadávana dostupných prekladov"
 
@@ -369,6 +369,10 @@ msgstr "Mapa prekladov"
 #. Default: "The migration of LinguaPlone content depends on an up-to-date Language index. Use this step to refresh this index. Warning: Depending on the number of items in your site, this can take a considerable amount of time."
 #: ../browser/templates/migration.pt:118
 msgid "help_reindex_language_index"
+msgstr ""
+
+#: ../browser/templates/add-form-is-translation.pt:15
+msgid "here"
 msgstr ""
 
 #. Default: "All translations"
@@ -392,7 +396,7 @@ msgid "label_cleanup"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:37
+#: ../browser/modify.py:39
 msgid "label_connect_translation"
 msgstr ""
 
@@ -434,7 +438,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:491
+#: ../browser/menu.py:494
 msgid "label_translate_menu"
 msgstr "Preložiť"
 
@@ -450,7 +454,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:462
+#: ../browser/menu.py:465
 msgid "language_folder"
 msgstr "Návrat do zložky jazyka"
 
@@ -475,7 +479,7 @@ msgid "legend_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "This form allows you to connect a currently existing translations of the current object."
-#: ../browser/modify.py:38
+#: ../browser/modify.py:40
 msgid "long_description_connect_translation"
 msgstr ""
 
@@ -495,7 +499,7 @@ msgid "not_configured_for_multiple_languages"
 msgstr ""
 
 #. Default: "All the configuration of a multilingual Plone site"
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid "pam_controlpanel_description"
 msgstr "Konfiguračný panel pre nastavenie jazykov. Ak chcete nastaviť predvolený jazyk pre všetky objekty bez nastavenia jazyka a presunúť obsah do zložky Predvolený jazyk, choďte do časti Ďalšie možnosti "
 
@@ -510,7 +514,7 @@ msgid "relation_migration_with_not_needed"
 msgstr ""
 
 #. Default: "Open ${title} folder"
-#: ../browser/menu.py:440
+#: ../browser/menu.py:443
 #, fuzzy
 msgid "shared_folder"
 msgstr "Choďte do zdieľanej zložky"
@@ -526,28 +530,28 @@ msgid "title_language"
 msgstr "Jazyk"
 
 #. Default: "Manage translations"
-#: ../browser/menu.py:215
+#: ../browser/menu.py:216
 msgid "title_modify_translations"
 msgstr ""
 
 #. Default: "Change content language"
-#: ../browser/menu.py:136
+#: ../browser/menu.py:137
 #, fuzzy
 msgid "title_set_language"
 msgstr "Nastavenie jazyka obsahu"
 
 #. Default: "Folder translation"
-#: ../browser/menu.py:258
+#: ../browser/menu.py:260
 msgid "title_translate_current_folder"
 msgstr ""
 
 #. Default: "Item translation"
-#: ../browser/menu.py:422
+#: ../browser/menu.py:425
 msgid "title_translate_current_item"
 msgstr ""
 
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:492
+#: ../browser/menu.py:495
 msgid "title_translate_menu"
 msgstr "Správa prekladov vášho obsahu."
 
@@ -562,7 +566,7 @@ msgid "translation_to"
 msgstr "Preklad do ${language}"
 
 #. Default: "Universal link"
-#: ../browser/menu.py:235
+#: ../browser/menu.py:237
 #, fuzzy
 msgid "universal_link"
 msgstr "Univerzálny odkaz"

--- a/src/plone/app/multilingual/locales/uk/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/uk/LC_MESSAGES/plone.app.multilingual.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone.app.multilingual\n"
-"POT-Creation-Date: 2017-07-13 21:35+0000\n"
+"POT-Creation-Date: 2018-03-19 06:49+0000\n"
 "PO-Revision-Date: 2013-02-08 00:35+0300\n"
 "Last-Translator: Roman Kozlovskyi <krzroman@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,15 +16,15 @@ msgstr ""
 "X-Poedit-Language: Ukrainian\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: ../browser/migrator.py:85
+#: ../browser/migrator.py:86
 msgid "After migration relation cleanup"
 msgstr "Очищення зв'язків після міграції"
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:60
 msgid "Cancel"
 msgstr ""
 
-#: ../browser/controlpanel.py:65
+#: ../browser/controlpanel.py:63
 msgid "Changes canceled."
 msgstr ""
 
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Cleanup"
 msgstr "Очистити"
 
-#: ../browser/controlpanel.py:49
+#: ../browser/controlpanel.py:47
 msgid "Default language not in available languages"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr "Однак, це список вже перекладених мов д�
 msgid "Install to enable multilingual content support with plone.app.multilingual"
 msgstr ""
 
-#: ../browser/translate.py:69
+#: ../browser/translate.py:70
 msgid "Invalid field"
 msgstr "Неправильне поле"
 
@@ -53,7 +53,7 @@ msgstr "Неправильне поле"
 msgid "Language control panel"
 msgstr "Панель управління мов"
 
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Make this content type multilingual aware"
 msgstr ""
 
@@ -62,16 +62,16 @@ msgid "Move"
 msgstr "Пересунути"
 
 #. Default: "Multilingual"
-#: ../interfaces.py:183
+#: ../interfaces.py:184
 msgid "Multilingual"
 msgstr ""
 
-#: ../browser/controlpanel.py:32
+#: ../browser/controlpanel.py:30
 msgid "Multilingual Settings"
 msgstr "Налаштування багатомовності"
 
 #: ../configure.zcml:151
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Multilingual Support"
 msgstr ""
 
@@ -79,11 +79,11 @@ msgstr ""
 msgid "Multilingual Support [uninstall]"
 msgstr ""
 
-#: ../browser/translate.py:54
+#: ../browser/translate.py:55
 msgid "Need a field"
 msgstr "Необхідно поле"
 
-#: ../browser/controlpanel.py:174
+#: ../browser/controlpanel.py:172
 msgid "Not translated"
 msgstr "Не перекладаються"
 
@@ -95,19 +95,19 @@ msgstr "Переіндексувати"
 msgid "Relocate"
 msgstr "Перемістити"
 
-#: ../browser/migrator.py:127
+#: ../browser/migrator.py:128
 msgid "Relocate content to the proper root language folder"
 msgstr "Перемістити контент у відповідну теку корінь мови"
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:36
 msgid "Save"
 msgstr ""
 
-#: ../interfaces.py:169
+#: ../interfaces.py:170
 msgid "Search for closest translation in parent's content chain."
 msgstr "Пошук найближчих перекладів з ланцюга батьків контенту."
 
-#: ../interfaces.py:172
+#: ../interfaces.py:173
 msgid "Show user dialog with information about the available translations."
 msgstr "Показати діалогове вікно з інформацією про доступні перекладм."
 
@@ -127,7 +127,7 @@ msgstr "Цей елемент ще не має ніякого перекладу
 msgid "Transfer"
 msgstr "Передача"
 
-#: ../browser/migrator.py:50
+#: ../browser/migrator.py:51
 msgid "Transfer multilingual catalog information"
 msgstr "Передача багатомовного інформаційного каталога"
 
@@ -139,23 +139,23 @@ msgstr ""
 msgid "Update bundle regristration"
 msgstr ""
 
-#. Default: "This object is going to be a translation to ${DYNAMIC_CONTENT} from: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "This object is going to be a translation to ${language} from:"
+#: ../browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
 msgstr ""
 
 #. Default: "assets"
-#: ../browser/setup.py:139
+#: ../browser/setup.py:140
 msgid "assets_folder_id"
 msgstr ""
 
 #. Default: "Assets"
-#: ../browser/setup.py:142
+#: ../browser/setup.py:143
 msgid "assets_folder_title"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:44
+#: ../browser/modify.py:46
 msgid "connect_translation"
 msgstr ""
 
@@ -163,13 +163,13 @@ msgstr ""
 msgid "content"
 msgstr "контент"
 
-#. Default: "If you want to create this object without being a translation press <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">here</a>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "If you want to create this object without being a translation press ${url}"
+#: ../browser/templates/add-form-is-translation.pt:15
 msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:161
+#: ../browser/menu.py:162
 msgid "create_translation"
 msgstr "Створити ${lang_name}"
 
@@ -179,33 +179,33 @@ msgid "description_after_migration_cleanup"
 msgstr "Цей крок виправить деякі втрачені залежності ITranslatable інтерфейсу приховані у каталогу зв'язків і позбавляється від них. Він може бути запущений тільки тоді, коли LinguaPlone вже видалений."
 
 #. Default: "Edit {lang_name} with the two-column translation view"
-#: ../browser/menu.py:117
+#: ../browser/menu.py:118
 #, fuzzy
 msgid "description_babeledit_menu"
 msgstr "Babel редагування ${lang_name}"
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
-#: ../interfaces.py:240
+#: ../interfaces.py:241
 msgid "description_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
-#: ../interfaces.py:221
+#: ../interfaces.py:222
 msgid "description_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter using language the content on folder_contents"
-#: ../interfaces.py:198
+#: ../interfaces.py:199
 msgid "description_filter_content"
 msgstr "ФІльтрувати використовуючи мову контенту на вмісті теки"
 
 #. Default: "Is a paying API in order to use google translation service"
-#: ../interfaces.py:256
+#: ../interfaces.py:257
 msgid "description_google_translation_key"
 msgstr "Чи є оплачено API для того, щоб використовувати Google перекладацькі послуги"
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:466
+#: ../browser/menu.py:469
 msgid "description_language_folder"
 msgstr "Перейти в теку мови вибрану браузером користувача"
 
@@ -225,12 +225,12 @@ msgid "description_migration_results"
 msgstr "Тут ви побачите результати процесу міграції"
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:219
+#: ../browser/menu.py:220
 msgid "description_modify_translations"
 msgstr ""
 
 #. Default: "After creating a new translation redirecto to babel view"
-#: ../interfaces.py:209
+#: ../interfaces.py:210
 msgid "description_redirect_babel_view"
 msgstr "Після створення нового перекладу перенаправити до babel вигляду"
 
@@ -245,18 +245,18 @@ msgid "description_relocate_content"
 msgstr "Цей крок перемість вмісту сайту у відповідні теки корені мов і попередньо зробить пошук недоречного контенту через вміст дерево сайту і перемістить їх до свого найближчого перекладеного батька. Цей крок є руйнівним, так як він буде змінювати вміст деревовидної структури. Переконайтеся, що ви правильно налаштували мову вашого сайту на вкладці 'Мови Cайту' панелі управління 'Мови'."
 
 #. Default: "The default language used for the content and the UI of this site."
-#: ../interfaces.py:268
+#: ../interfaces.py:269
 msgid "description_selector_lookup_translations_policy"
 msgstr "Мова за замовчуванням використовується для контенту і користувальницького інтерфейсу цього сайту."
 
 #. Default: "Move the translation under another language folder"
-#: ../browser/menu.py:140
+#: ../browser/menu.py:141
 #, fuzzy
 msgid "description_set_language"
 msgstr "Встановити або змінити мову даного контенту"
 
 #. Default: "Open the language independent assets folder"
-#: ../browser/menu.py:445
+#: ../browser/menu.py:448
 #, fuzzy
 msgid "description_shared_folder"
 msgstr "Показати мову загальної (нейтральної мови) теки"
@@ -267,7 +267,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr "Цей крок буде перетворювати зв'язки між переклади збережені LinguaPlone в каталозі PAM. Цей крок не є руйнівним і може виконатьсь стільки разів, скільки необхідно."
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:166
+#: ../browser/menu.py:167
 msgid "description_translate_into"
 msgstr "Перекласти на ${lang_name}"
 
@@ -277,7 +277,7 @@ msgid "description_translation_map"
 msgstr "Карта перекладів."
 
 #. Default: "Universal link to the content in user's preferred language"
-#: ../browser/menu.py:239
+#: ../browser/menu.py:241
 #, fuzzy
 msgid "description_universal_link"
 msgstr "Універсальне мовне посилання на контент"
@@ -288,22 +288,22 @@ msgid "description_update_language"
 msgstr "Неперекладені мови з поточного контенту"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:112
+#: ../browser/menu.py:113
 msgid "edit_translation"
 msgstr "Редагувати ${lang_name}"
 
 #. Default: "Folder's id is not a valid language code"
-#: ../browser/migrator.py:308
+#: ../browser/migrator.py:309
 msgid "folder_to_lrf_id_not_language"
 msgstr ""
 
 #. Default: "Only folders just below the root can be transformed"
-#: ../browser/migrator.py:297
+#: ../browser/migrator.py:298
 msgid "folder_to_lrf_not_next_to_root"
 msgstr ""
 
 #. Default: "Folder has been successfully transformed to a language root folder"
-#: ../browser/migrator.py:331
+#: ../browser/migrator.py:332
 msgid "folder_to_lrf_success"
 msgstr ""
 
@@ -313,22 +313,22 @@ msgid "heading_available_translations"
 msgstr "Наявні переклади"
 
 #. Default: "Use buttons in the bable view for up to how many translations?"
-#: ../interfaces.py:236
+#: ../interfaces.py:237
 msgid "heading_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "Bypass language independent field permission check"
-#: ../interfaces.py:218
+#: ../interfaces.py:219
 msgid "heading_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter content by language."
-#: ../interfaces.py:195
+#: ../interfaces.py:196
 msgid "heading_filter_content"
 msgstr "Фільтрувати коттент за мовою"
 
 #. Default: "Google Translation API Key"
-#: ../interfaces.py:253
+#: ../interfaces.py:254
 msgid "heading_google_translation_key"
 msgstr "Google Перекладач API ключ"
 
@@ -353,12 +353,12 @@ msgid "heading_not_available_in_language"
 msgstr "Немає в наявності на ${language}"
 
 #. Default: "Redirect on creation to babel view."
-#: ../interfaces.py:206
+#: ../interfaces.py:207
 msgid "heading_redirect_babel_view"
 msgstr "Перенаправлення по створенню на babel вигляд."
 
 #. Default: "The policy used to determine how the lookup for available translations will be made by the language selector."
-#: ../interfaces.py:264
+#: ../interfaces.py:265
 msgid "heading_selector_lookup_translations_policy"
 msgstr "Політика, що використовується для визначення того, як шукатимуться доступні переклади при виборі мови."
 
@@ -371,6 +371,10 @@ msgstr "plone.app.multilingual карта перекладів"
 #: ../browser/templates/migration.pt:118
 msgid "help_reindex_language_index"
 msgstr "Міграція контенту LinguaPlone залежить від того, чи оновлений індекс мови. Використовуйте цей крок, щоб оновити цей індекс. Попередження: в залежності від числа елементів в вашому сайті, це може зайняти значну кількість часу."
+
+#: ../browser/templates/add-form-is-translation.pt:15
+msgid "here"
+msgstr ""
 
 #. Default: "All translations"
 #: ../browser/templates/mmap.pt:75
@@ -393,7 +397,7 @@ msgid "label_cleanup"
 msgstr "Очищення дії"
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:37
+#: ../browser/modify.py:39
 msgid "label_connect_translation"
 msgstr ""
 
@@ -435,7 +439,7 @@ msgid "label_total_relations"
 msgstr "Кількість задіяних зв'язків:"
 
 #. Default: "Translate"
-#: ../browser/menu.py:491
+#: ../browser/menu.py:494
 msgid "label_translate_menu"
 msgstr "Перекласти"
 
@@ -451,7 +455,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:462
+#: ../browser/menu.py:465
 msgid "language_folder"
 msgstr "Повернутися в папку мови"
 
@@ -476,7 +480,7 @@ msgid "legend_transfer_multilingual_catalog_info"
 msgstr "Крок 2 - Передача багатомовного інформаційного каталогу"
 
 #. Default: "This form allows you to connect a currently existing translations of the current object."
-#: ../browser/modify.py:38
+#: ../browser/modify.py:40
 msgid "long_description_connect_translation"
 msgstr ""
 
@@ -496,7 +500,7 @@ msgid "not_configured_for_multiple_languages"
 msgstr "Ваш сайт не налаштований для більш ніж однієї дозволеної мови, але доповнення, яке забезпечує підтримку для утримання кількох мов встановлено. Ви можете додати одну або кілька додаткових мов з ${control-panel-link}."
 
 #. Default: "All the configuration of a multilingual Plone site"
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid "pam_controlpanel_description"
 msgstr "Вся конфігурація P.A.M. Якщо ви хочете встановити мову за замовчуванням для всього контенту без мови і перемістити весь вміст кореневої теки в у теку мови за замовчуванням, перейдіть в розділ Додаткові параметри"
 
@@ -511,7 +515,7 @@ msgid "relation_migration_with_not_needed"
 msgstr "Ваш сайт не має ніякого каталогу відношення, і тому цей крок міграції не вимагається"
 
 #. Default: "Open ${title} folder"
-#: ../browser/menu.py:440
+#: ../browser/menu.py:443
 #, fuzzy
 msgid "shared_folder"
 msgstr "Перейти до спільної теки"
@@ -527,28 +531,28 @@ msgid "title_language"
 msgstr "Мова"
 
 #. Default: "Manage translations"
-#: ../browser/menu.py:215
+#: ../browser/menu.py:216
 msgid "title_modify_translations"
 msgstr ""
 
 #. Default: "Change content language"
-#: ../browser/menu.py:136
+#: ../browser/menu.py:137
 #, fuzzy
 msgid "title_set_language"
 msgstr "Встановити мову контенту"
 
 #. Default: "Folder translation"
-#: ../browser/menu.py:258
+#: ../browser/menu.py:260
 msgid "title_translate_current_folder"
 msgstr ""
 
 #. Default: "Item translation"
-#: ../browser/menu.py:422
+#: ../browser/menu.py:425
 msgid "title_translate_current_item"
 msgstr ""
 
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:492
+#: ../browser/menu.py:495
 msgid "title_translate_menu"
 msgstr "Управління перекладами вашого контенту."
 
@@ -563,7 +567,7 @@ msgid "translation_to"
 msgstr "Переклад на ${language}"
 
 #. Default: "Universal link"
-#: ../browser/menu.py:235
+#: ../browser/menu.py:237
 #, fuzzy
 msgid "universal_link"
 msgstr "Універсальне посилання"

--- a/src/plone/app/multilingual/locales/zh_CN/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/zh_CN/LC_MESSAGES/plone.app.multilingual.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-07-13 21:35+0000\n"
+"POT-Creation-Date: 2018-03-19 06:49+0000\n"
 "PO-Revision-Date: 2012-03-24 23:31+0800\n"
 "Last-Translator: Jian Aijun <jianaijun@gmail.com>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
@@ -17,15 +17,15 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: plone.app.multilingual\n"
 
-#: ../browser/migrator.py:85
+#: ../browser/migrator.py:86
 msgid "After migration relation cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:60
 msgid "Cancel"
 msgstr ""
 
-#: ../browser/controlpanel.py:65
+#: ../browser/controlpanel.py:63
 msgid "Changes canceled."
 msgstr ""
 
@@ -34,7 +34,7 @@ msgstr ""
 msgid "Cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:49
+#: ../browser/controlpanel.py:47
 msgid "Default language not in available languages"
 msgstr ""
 
@@ -46,7 +46,7 @@ msgstr ""
 msgid "Install to enable multilingual content support with plone.app.multilingual"
 msgstr ""
 
-#: ../browser/translate.py:69
+#: ../browser/translate.py:70
 msgid "Invalid field"
 msgstr ""
 
@@ -54,7 +54,7 @@ msgstr ""
 msgid "Language control panel"
 msgstr ""
 
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Make this content type multilingual aware"
 msgstr ""
 
@@ -63,16 +63,16 @@ msgid "Move"
 msgstr ""
 
 #. Default: "Multilingual"
-#: ../interfaces.py:183
+#: ../interfaces.py:184
 msgid "Multilingual"
 msgstr ""
 
-#: ../browser/controlpanel.py:32
+#: ../browser/controlpanel.py:30
 msgid "Multilingual Settings"
 msgstr "多语言设置"
 
 #: ../configure.zcml:151
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Multilingual Support"
 msgstr ""
 
@@ -80,11 +80,11 @@ msgstr ""
 msgid "Multilingual Support [uninstall]"
 msgstr ""
 
-#: ../browser/translate.py:54
+#: ../browser/translate.py:55
 msgid "Need a field"
 msgstr ""
 
-#: ../browser/controlpanel.py:174
+#: ../browser/controlpanel.py:172
 msgid "Not translated"
 msgstr ""
 
@@ -96,19 +96,19 @@ msgstr ""
 msgid "Relocate"
 msgstr ""
 
-#: ../browser/migrator.py:127
+#: ../browser/migrator.py:128
 msgid "Relocate content to the proper root language folder"
 msgstr ""
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:36
 msgid "Save"
 msgstr ""
 
-#: ../interfaces.py:169
+#: ../interfaces.py:170
 msgid "Search for closest translation in parent's content chain."
 msgstr ""
 
-#: ../interfaces.py:172
+#: ../interfaces.py:173
 msgid "Show user dialog with information about the available translations."
 msgstr ""
 
@@ -128,7 +128,7 @@ msgstr ""
 msgid "Transfer"
 msgstr ""
 
-#: ../browser/migrator.py:50
+#: ../browser/migrator.py:51
 msgid "Transfer multilingual catalog information"
 msgstr ""
 
@@ -140,23 +140,23 @@ msgstr ""
 msgid "Update bundle regristration"
 msgstr ""
 
-#. Default: "This object is going to be a translation to ${DYNAMIC_CONTENT} from: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "This object is going to be a translation to ${language} from:"
+#: ../browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
 msgstr ""
 
 #. Default: "assets"
-#: ../browser/setup.py:139
+#: ../browser/setup.py:140
 msgid "assets_folder_id"
 msgstr ""
 
 #. Default: "Assets"
-#: ../browser/setup.py:142
+#: ../browser/setup.py:143
 msgid "assets_folder_title"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:44
+#: ../browser/modify.py:46
 msgid "connect_translation"
 msgstr ""
 
@@ -164,13 +164,13 @@ msgstr ""
 msgid "content"
 msgstr "内容"
 
-#. Default: "If you want to create this object without being a translation press <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">here</a>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "If you want to create this object without being a translation press ${url}"
+#: ../browser/templates/add-form-is-translation.pt:15
 msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:161
+#: ../browser/menu.py:162
 msgid "create_translation"
 msgstr ""
 
@@ -180,32 +180,32 @@ msgid "description_after_migration_cleanup"
 msgstr ""
 
 #. Default: "Edit {lang_name} with the two-column translation view"
-#: ../browser/menu.py:117
+#: ../browser/menu.py:118
 msgid "description_babeledit_menu"
 msgstr ""
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
-#: ../interfaces.py:240
+#: ../interfaces.py:241
 msgid "description_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
-#: ../interfaces.py:221
+#: ../interfaces.py:222
 msgid "description_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter using language the content on folder_contents"
-#: ../interfaces.py:198
+#: ../interfaces.py:199
 msgid "description_filter_content"
 msgstr ""
 
 #. Default: "Is a paying API in order to use google translation service"
-#: ../interfaces.py:256
+#: ../interfaces.py:257
 msgid "description_google_translation_key"
 msgstr ""
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:466
+#: ../browser/menu.py:469
 msgid "description_language_folder"
 msgstr ""
 
@@ -225,12 +225,12 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:219
+#: ../browser/menu.py:220
 msgid "description_modify_translations"
 msgstr ""
 
 #. Default: "After creating a new translation redirecto to babel view"
-#: ../interfaces.py:209
+#: ../interfaces.py:210
 msgid "description_redirect_babel_view"
 msgstr ""
 
@@ -245,17 +245,17 @@ msgid "description_relocate_content"
 msgstr ""
 
 #. Default: "The default language used for the content and the UI of this site."
-#: ../interfaces.py:268
+#: ../interfaces.py:269
 msgid "description_selector_lookup_translations_policy"
 msgstr ""
 
 #. Default: "Move the translation under another language folder"
-#: ../browser/menu.py:140
+#: ../browser/menu.py:141
 msgid "description_set_language"
 msgstr ""
 
 #. Default: "Open the language independent assets folder"
-#: ../browser/menu.py:445
+#: ../browser/menu.py:448
 msgid "description_shared_folder"
 msgstr ""
 
@@ -265,7 +265,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:166
+#: ../browser/menu.py:167
 msgid "description_translate_into"
 msgstr "翻译成 ${lang_name}"
 
@@ -275,7 +275,7 @@ msgid "description_translation_map"
 msgstr ""
 
 #. Default: "Universal link to the content in user's preferred language"
-#: ../browser/menu.py:239
+#: ../browser/menu.py:241
 msgid "description_universal_link"
 msgstr ""
 
@@ -285,22 +285,22 @@ msgid "description_update_language"
 msgstr ""
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:112
+#: ../browser/menu.py:113
 msgid "edit_translation"
 msgstr ""
 
 #. Default: "Folder's id is not a valid language code"
-#: ../browser/migrator.py:308
+#: ../browser/migrator.py:309
 msgid "folder_to_lrf_id_not_language"
 msgstr ""
 
 #. Default: "Only folders just below the root can be transformed"
-#: ../browser/migrator.py:297
+#: ../browser/migrator.py:298
 msgid "folder_to_lrf_not_next_to_root"
 msgstr ""
 
 #. Default: "Folder has been successfully transformed to a language root folder"
-#: ../browser/migrator.py:331
+#: ../browser/migrator.py:332
 msgid "folder_to_lrf_success"
 msgstr ""
 
@@ -310,22 +310,22 @@ msgid "heading_available_translations"
 msgstr ""
 
 #. Default: "Use buttons in the bable view for up to how many translations?"
-#: ../interfaces.py:236
+#: ../interfaces.py:237
 msgid "heading_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "Bypass language independent field permission check"
-#: ../interfaces.py:218
+#: ../interfaces.py:219
 msgid "heading_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter content by language."
-#: ../interfaces.py:195
+#: ../interfaces.py:196
 msgid "heading_filter_content"
 msgstr ""
 
 #. Default: "Google Translation API Key"
-#: ../interfaces.py:253
+#: ../interfaces.py:254
 msgid "heading_google_translation_key"
 msgstr ""
 
@@ -350,12 +350,12 @@ msgid "heading_not_available_in_language"
 msgstr ""
 
 #. Default: "Redirect on creation to babel view."
-#: ../interfaces.py:206
+#: ../interfaces.py:207
 msgid "heading_redirect_babel_view"
 msgstr ""
 
 #. Default: "The policy used to determine how the lookup for available translations will be made by the language selector."
-#: ../interfaces.py:264
+#: ../interfaces.py:265
 msgid "heading_selector_lookup_translations_policy"
 msgstr ""
 
@@ -367,6 +367,10 @@ msgstr ""
 #. Default: "The migration of LinguaPlone content depends on an up-to-date Language index. Use this step to refresh this index. Warning: Depending on the number of items in your site, this can take a considerable amount of time."
 #: ../browser/templates/migration.pt:118
 msgid "help_reindex_language_index"
+msgstr ""
+
+#: ../browser/templates/add-form-is-translation.pt:15
+msgid "here"
 msgstr ""
 
 #. Default: "All translations"
@@ -390,7 +394,7 @@ msgid "label_cleanup"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:37
+#: ../browser/modify.py:39
 msgid "label_connect_translation"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:491
+#: ../browser/menu.py:494
 #, fuzzy
 msgid "label_translate_menu"
 msgstr "翻译成..."
@@ -449,7 +453,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:462
+#: ../browser/menu.py:465
 msgid "language_folder"
 msgstr ""
 
@@ -474,7 +478,7 @@ msgid "legend_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "This form allows you to connect a currently existing translations of the current object."
-#: ../browser/modify.py:38
+#: ../browser/modify.py:40
 msgid "long_description_connect_translation"
 msgstr ""
 
@@ -494,7 +498,7 @@ msgid "not_configured_for_multiple_languages"
 msgstr ""
 
 #. Default: "All the configuration of a multilingual Plone site"
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid "pam_controlpanel_description"
 msgstr ""
 
@@ -509,7 +513,7 @@ msgid "relation_migration_with_not_needed"
 msgstr ""
 
 #. Default: "Open ${title} folder"
-#: ../browser/menu.py:440
+#: ../browser/menu.py:443
 msgid "shared_folder"
 msgstr ""
 
@@ -524,27 +528,27 @@ msgid "title_language"
 msgstr "语言"
 
 #. Default: "Manage translations"
-#: ../browser/menu.py:215
+#: ../browser/menu.py:216
 msgid "title_modify_translations"
 msgstr ""
 
 #. Default: "Change content language"
-#: ../browser/menu.py:136
+#: ../browser/menu.py:137
 msgid "title_set_language"
 msgstr ""
 
 #. Default: "Folder translation"
-#: ../browser/menu.py:258
+#: ../browser/menu.py:260
 msgid "title_translate_current_folder"
 msgstr ""
 
 #. Default: "Item translation"
-#: ../browser/menu.py:422
+#: ../browser/menu.py:425
 msgid "title_translate_current_item"
 msgstr ""
 
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:492
+#: ../browser/menu.py:495
 msgid "title_translate_menu"
 msgstr "为您的内容管理翻译。"
 
@@ -559,7 +563,7 @@ msgid "translation_to"
 msgstr ""
 
 #. Default: "Universal link"
-#: ../browser/menu.py:235
+#: ../browser/menu.py:237
 msgid "universal_link"
 msgstr ""
 

--- a/src/plone/app/multilingual/locales/zh_TW/LC_MESSAGES/plone.app.multilingual.po
+++ b/src/plone/app/multilingual/locales/zh_TW/LC_MESSAGES/plone.app.multilingual.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone.app.multilingual\n"
-"POT-Creation-Date: 2017-07-13 21:35+0000\n"
+"POT-Creation-Date: 2018-03-19 06:49+0000\n"
 "PO-Revision-Date: 2015-11-27 14:20+0800\n"
 "Last-Translator: TsungWei Hu <marr.tw@gmail.com>\n"
 "Language-Team: Plone I18N <plone-i18n@lists.sourcegorge.net>\n"
@@ -14,15 +14,15 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: plone.app.multilingual\n"
 
-#: ../browser/migrator.py:85
+#: ../browser/migrator.py:86
 msgid "After migration relation cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:62
+#: ../browser/controlpanel.py:60
 msgid "Cancel"
 msgstr ""
 
-#: ../browser/controlpanel.py:65
+#: ../browser/controlpanel.py:63
 msgid "Changes canceled."
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr ""
 msgid "Cleanup"
 msgstr ""
 
-#: ../browser/controlpanel.py:49
+#: ../browser/controlpanel.py:47
 msgid "Default language not in available languages"
 msgstr ""
 
@@ -43,7 +43,7 @@ msgstr "不過，下列是已經完成翻譯的語系清單："
 msgid "Install to enable multilingual content support with plone.app.multilingual"
 msgstr ""
 
-#: ../browser/translate.py:69
+#: ../browser/translate.py:70
 msgid "Invalid field"
 msgstr "欄位錯誤"
 
@@ -51,7 +51,7 @@ msgstr "欄位錯誤"
 msgid "Language control panel"
 msgstr "語系翻譯控制面板"
 
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Make this content type multilingual aware"
 msgstr ""
 
@@ -60,16 +60,16 @@ msgid "Move"
 msgstr "移動"
 
 #. Default: "Multilingual"
-#: ../interfaces.py:183
+#: ../interfaces.py:184
 msgid "Multilingual"
 msgstr ""
 
-#: ../browser/controlpanel.py:32
+#: ../browser/controlpanel.py:30
 msgid "Multilingual Settings"
 msgstr "語系翻譯設定"
 
 #: ../configure.zcml:151
-#: ../dx/configure.zcml:36
+#: ../dx/configure.zcml:37
 msgid "Multilingual Support"
 msgstr ""
 
@@ -77,11 +77,11 @@ msgstr ""
 msgid "Multilingual Support [uninstall]"
 msgstr ""
 
-#: ../browser/translate.py:54
+#: ../browser/translate.py:55
 msgid "Need a field"
 msgstr "需要欄位"
 
-#: ../browser/controlpanel.py:174
+#: ../browser/controlpanel.py:172
 msgid "Not translated"
 msgstr "未翻譯"
 
@@ -93,19 +93,19 @@ msgstr ""
 msgid "Relocate"
 msgstr ""
 
-#: ../browser/migrator.py:127
+#: ../browser/migrator.py:128
 msgid "Relocate content to the proper root language folder"
 msgstr ""
 
-#: ../browser/controlpanel.py:38
+#: ../browser/controlpanel.py:36
 msgid "Save"
 msgstr ""
 
-#: ../interfaces.py:169
+#: ../interfaces.py:170
 msgid "Search for closest translation in parent's content chain."
 msgstr ""
 
-#: ../interfaces.py:172
+#: ../interfaces.py:173
 msgid "Show user dialog with information about the available translations."
 msgstr ""
 
@@ -125,7 +125,7 @@ msgstr "這個項目完全沒有翻譯，你可以回到它的原始網址："
 msgid "Transfer"
 msgstr ""
 
-#: ../browser/migrator.py:50
+#: ../browser/migrator.py:51
 msgid "Transfer multilingual catalog information"
 msgstr ""
 
@@ -137,23 +137,23 @@ msgstr ""
 msgid "Update bundle regristration"
 msgstr ""
 
-#. Default: "This object is going to be a translation to ${DYNAMIC_CONTENT} from: <ul> <li><a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\"> <span>${DYNAMIC_CONTENT}</span> <span>${DYNAMIC_CONTENT}</span></a></li> </ul> <span>x</span>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "This object is going to be a translation to ${language} from:"
+#: ../browser/templates/add-form-is-translation.pt:8
 msgid "add-form-is-translation"
 msgstr ""
 
 #. Default: "assets"
-#: ../browser/setup.py:139
+#: ../browser/setup.py:140
 msgid "assets_folder_id"
 msgstr ""
 
 #. Default: "Assets"
-#: ../browser/setup.py:142
+#: ../browser/setup.py:143
 msgid "assets_folder_title"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:44
+#: ../browser/modify.py:46
 msgid "connect_translation"
 msgstr ""
 
@@ -161,13 +161,13 @@ msgstr ""
 msgid "content"
 msgstr "內容"
 
-#. Default: "If you want to create this object without being a translation press <a href=\"${DYNAMIC_CONTENT}\" class=\"link-overlay\">here</a>"
-#: ../browser/templates/add-form-is-translation.pt:14
+#. Default: "If you want to create this object without being a translation press ${url}"
+#: ../browser/templates/add-form-is-translation.pt:15
 msgid "create-object-without-translation"
 msgstr ""
 
 #. Default: "Create ${lang_name}"
-#: ../browser/menu.py:161
+#: ../browser/menu.py:162
 msgid "create_translation"
 msgstr "新增 ${lang_name}"
 
@@ -177,33 +177,33 @@ msgid "description_after_migration_cleanup"
 msgstr ""
 
 #. Default: "Edit {lang_name} with the two-column translation view"
-#: ../browser/menu.py:117
+#: ../browser/menu.py:118
 #, fuzzy
 msgid "description_babeledit_menu"
 msgstr "編輯 ${lang_name}"
 
 #. Default: "When there are many translations for an item, the number of displayed buttons for them might get too large to fit inside the template. Choose here from which number onwards a drop-down menu will be displayed instead of buttons. Zero means that buttons will always be used."
-#: ../interfaces.py:240
+#: ../interfaces.py:241
 msgid "description_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "When updating an object with language independent the field will be synced to all target languages. That can produce Unauthorized error messages because if the editor of the canonical object is not allowed to update the target language objects. Enabling this bypasses this permission check. This could also be dangerous, so think about possible security issues before enabling this."
-#: ../interfaces.py:221
+#: ../interfaces.py:222
 msgid "description_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter using language the content on folder_contents"
-#: ../interfaces.py:198
+#: ../interfaces.py:199
 msgid "description_filter_content"
 msgstr ""
 
 #. Default: "Is a paying API in order to use google translation service"
-#: ../interfaces.py:256
+#: ../interfaces.py:257
 msgid "description_google_translation_key"
 msgstr ""
 
 #. Default: "Go to the user's browser preferred language related folder"
-#: ../browser/menu.py:466
+#: ../browser/menu.py:469
 msgid "description_language_folder"
 msgstr "回到瀏覽器預設語系的目錄"
 
@@ -223,12 +223,12 @@ msgid "description_migration_results"
 msgstr ""
 
 #. Default: "Add or delete translations"
-#: ../browser/menu.py:219
+#: ../browser/menu.py:220
 msgid "description_modify_translations"
 msgstr ""
 
 #. Default: "After creating a new translation redirecto to babel view"
-#: ../interfaces.py:209
+#: ../interfaces.py:210
 msgid "description_redirect_babel_view"
 msgstr ""
 
@@ -243,18 +243,18 @@ msgid "description_relocate_content"
 msgstr ""
 
 #. Default: "The default language used for the content and the UI of this site."
-#: ../interfaces.py:268
+#: ../interfaces.py:269
 msgid "description_selector_lookup_translations_policy"
 msgstr ""
 
 #. Default: "Move the translation under another language folder"
-#: ../browser/menu.py:140
+#: ../browser/menu.py:141
 #, fuzzy
 msgid "description_set_language"
 msgstr "設定目前的內容語系"
 
 #. Default: "Open the language independent assets folder"
-#: ../browser/menu.py:445
+#: ../browser/menu.py:448
 #, fuzzy
 msgid "description_shared_folder"
 msgstr "顯示語系共享的目錄"
@@ -265,7 +265,7 @@ msgid "description_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "Translate into ${lang_name}"
-#: ../browser/menu.py:166
+#: ../browser/menu.py:167
 msgid "description_translate_into"
 msgstr "翻譯為 ${lang_name}"
 
@@ -275,7 +275,7 @@ msgid "description_translation_map"
 msgstr ""
 
 #. Default: "Universal link to the content in user's preferred language"
-#: ../browser/menu.py:239
+#: ../browser/menu.py:241
 #, fuzzy
 msgid "description_universal_link"
 msgstr "Universal Language 網址"
@@ -286,22 +286,22 @@ msgid "description_update_language"
 msgstr "這個內容尚未翻譯的語系"
 
 #. Default: "Edit ${lang_name}"
-#: ../browser/menu.py:112
+#: ../browser/menu.py:113
 msgid "edit_translation"
 msgstr "編輯 ${lang_name}"
 
 #. Default: "Folder's id is not a valid language code"
-#: ../browser/migrator.py:308
+#: ../browser/migrator.py:309
 msgid "folder_to_lrf_id_not_language"
 msgstr ""
 
 #. Default: "Only folders just below the root can be transformed"
-#: ../browser/migrator.py:297
+#: ../browser/migrator.py:298
 msgid "folder_to_lrf_not_next_to_root"
 msgstr ""
 
 #. Default: "Folder has been successfully transformed to a language root folder"
-#: ../browser/migrator.py:331
+#: ../browser/migrator.py:332
 msgid "folder_to_lrf_success"
 msgstr ""
 
@@ -311,22 +311,22 @@ msgid "heading_available_translations"
 msgstr ""
 
 #. Default: "Use buttons in the bable view for up to how many translations?"
-#: ../interfaces.py:236
+#: ../interfaces.py:237
 msgid "heading_buttons_babel_view_up_to_nr_translations"
 msgstr ""
 
 #. Default: "Bypass language independent field permission check"
-#: ../interfaces.py:218
+#: ../interfaces.py:219
 msgid "heading_bypass_languageindependent_field_permission_check"
 msgstr ""
 
 #. Default: "Filter content by language."
-#: ../interfaces.py:195
+#: ../interfaces.py:196
 msgid "heading_filter_content"
 msgstr ""
 
 #. Default: "Google Translation API Key"
-#: ../interfaces.py:253
+#: ../interfaces.py:254
 msgid "heading_google_translation_key"
 msgstr ""
 
@@ -351,12 +351,12 @@ msgid "heading_not_available_in_language"
 msgstr "沒有 ${language} 翻譯內容"
 
 #. Default: "Redirect on creation to babel view."
-#: ../interfaces.py:206
+#: ../interfaces.py:207
 msgid "heading_redirect_babel_view"
 msgstr ""
 
 #. Default: "The policy used to determine how the lookup for available translations will be made by the language selector."
-#: ../interfaces.py:264
+#: ../interfaces.py:265
 msgid "heading_selector_lookup_translations_policy"
 msgstr ""
 
@@ -368,6 +368,10 @@ msgstr ""
 #. Default: "The migration of LinguaPlone content depends on an up-to-date Language index. Use this step to refresh this index. Warning: Depending on the number of items in your site, this can take a considerable amount of time."
 #: ../browser/templates/migration.pt:118
 msgid "help_reindex_language_index"
+msgstr ""
+
+#: ../browser/templates/add-form-is-translation.pt:15
+msgid "here"
 msgstr ""
 
 #. Default: "All translations"
@@ -391,7 +395,7 @@ msgid "label_cleanup"
 msgstr ""
 
 #. Default: "Connect translation"
-#: ../browser/modify.py:37
+#: ../browser/modify.py:39
 msgid "label_connect_translation"
 msgstr ""
 
@@ -433,7 +437,7 @@ msgid "label_total_relations"
 msgstr ""
 
 #. Default: "Translate"
-#: ../browser/menu.py:491
+#: ../browser/menu.py:494
 msgid "label_translate_menu"
 msgstr "翻譯"
 
@@ -449,7 +453,7 @@ msgid "label_translations_should_be_here"
 msgstr ""
 
 #. Default: "Return to language folder"
-#: ../browser/menu.py:462
+#: ../browser/menu.py:465
 msgid "language_folder"
 msgstr "回到語系目錄"
 
@@ -474,7 +478,7 @@ msgid "legend_transfer_multilingual_catalog_info"
 msgstr ""
 
 #. Default: "This form allows you to connect a currently existing translations of the current object."
-#: ../browser/modify.py:38
+#: ../browser/modify.py:40
 msgid "long_description_connect_translation"
 msgstr ""
 
@@ -494,7 +498,7 @@ msgid "not_configured_for_multiple_languages"
 msgstr ""
 
 #. Default: "All the configuration of a multilingual Plone site"
-#: ../browser/controlpanel.py:33
+#: ../browser/controlpanel.py:31
 msgid "pam_controlpanel_description"
 msgstr ""
 
@@ -509,7 +513,7 @@ msgid "relation_migration_with_not_needed"
 msgstr "網站裡找不到 relation catalog 所以不需要執行昇級步驟。"
 
 #. Default: "Open ${title} folder"
-#: ../browser/menu.py:440
+#: ../browser/menu.py:443
 #, fuzzy
 msgid "shared_folder"
 msgstr "回到共享目錄"
@@ -525,28 +529,28 @@ msgid "title_language"
 msgstr "語系"
 
 #. Default: "Manage translations"
-#: ../browser/menu.py:215
+#: ../browser/menu.py:216
 msgid "title_modify_translations"
 msgstr ""
 
 #. Default: "Change content language"
-#: ../browser/menu.py:136
+#: ../browser/menu.py:137
 #, fuzzy
 msgid "title_set_language"
 msgstr "設定內容語系"
 
 #. Default: "Folder translation"
-#: ../browser/menu.py:258
+#: ../browser/menu.py:260
 msgid "title_translate_current_folder"
 msgstr ""
 
 #. Default: "Item translation"
-#: ../browser/menu.py:422
+#: ../browser/menu.py:425
 msgid "title_translate_current_item"
 msgstr ""
 
 #. Default: "Manage translations for your content."
-#: ../browser/menu.py:492
+#: ../browser/menu.py:495
 msgid "title_translate_menu"
 msgstr "管理項目的翻譯"
 
@@ -561,7 +565,7 @@ msgid "translation_to"
 msgstr "翻譯成 ${language}"
 
 #. Default: "Universal link"
-#: ../browser/menu.py:235
+#: ../browser/menu.py:237
 #, fuzzy
 msgid "universal_link"
 msgstr "Universal Link"

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -8,5 +8,5 @@ plone-series = 5.1
 [versions]
 # Plone 5.1 needs a plone.app.layout release from the 2.6.x series
 plone.app.layout = 2.6.3
-setuptools==34.3.0
-zc.buildout==2.8.0
+setuptools = 34.3.0
+zc.buildout = 2.8.0


### PR DESCRIPTION
A viewlet is shown in the view to create a new translation (the view with the original content on the left and the translation on the right) which has errors

More over, the markup of the viewlet template is wrong because it creates a PO file with ${DYNAMIC_CONTENT} markers instead of proper variables created using i18n:name tags.

I have reworked the viewlet to show the links correctly, produce correct template markup and show language names with native names instead of language codes.



