### PR TITLE
Improve uninstall

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ New features:
 
 Bug fixes:
 
+- Remove `language-switcher` from available view methods when uninstalling
+  [erral]
+
 - Fix i18n markup in multilingual map to avoid ${DYNAMIC_CONTENT} strings in po files
   [erral]
 

--- a/src/plone/app/multilingual/setuphandlers.py
+++ b/src/plone/app/multilingual/setuphandlers.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+from logging import getLogger
 from plone.app.multilingual.browser.setup import SetupMultilingualSite
 from Products.CMFPlone.interfaces import INonInstallable
+from Products.CMFPlone.utils import getToolByName
 from zope.component.hooks import getSite
 from zope.interface import implementer
 
@@ -63,6 +65,7 @@ def step_uninstall_various(context):
         return
     portal = context.getSite()
     disable_translatable_behavior(portal)
+    disable_language_switcher(portal)
 
 
 def disable_translatable_behavior(portal):
@@ -81,3 +84,16 @@ def disable_translatable_behavior(portal):
             'plone.app.multilingual.dx.interfaces.IDexterityTranslatable'
         ]
         fti._updateProperty('behaviors', behaviors)
+
+
+def disable_language_switcher(portal):
+    """Remove the use of language-switcher as default view for Plone Site"""
+    tt = getToolByName(portal, 'portal_types')
+    site = tt['Plone Site']
+    methods = site.view_methods
+    site.view_methods = [m for m in methods if m != 'language-switcher']
+    if site.default_view == 'language-switcher':
+        site.default_view = 'listing_view'
+
+    log = getLogger('setuphandlers.disable_language_switcher')
+    log.info('Language switcher disabled')

--- a/src/plone/app/multilingual/tests/test_uninstall.py
+++ b/src/plone/app/multilingual/tests/test_uninstall.py
@@ -1,0 +1,44 @@
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.multilingual.testing import PLONE_APP_MULTILINGUAL_INTEGRATION_TESTING  # noqa
+
+import unittest
+
+class TestUninstall(unittest.TestCase):
+
+    layer = PLONE_APP_MULTILINGUAL_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.installer = api.portal.get_tool('portal_quickinstaller')
+        roles_before = api.user.get_roles(TEST_USER_ID)
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        self.installer.uninstallProducts(['plone.app.multilingual'])
+        setRoles(self.portal, TEST_USER_ID, roles_before)
+
+    def test_product_uninstalled(self):
+        """Test if plone.app.multilingual is cleanly uninstalled."""
+        self.assertFalse(self.installer.isProductInstalled(
+            'plone.app.multilingual'))
+
+    def test_browserlayer_removed(self):
+        """Test that IPloneAppMultilingualInstalled is removed."""
+        from plone.app.multilingual.interfaces import \
+            IPloneAppMultilingualInstalled
+        from plone.browserlayer import utils
+        self.assertNotIn(
+           IPloneAppMultilingualInstalled,
+           utils.registered_layers())
+
+    def test_language_switcher_not_in_available_view_methods(self):
+        self.assertNotIn(
+            'language-switcher',
+            self.portal.portal_types['Plone Site'].view_methods
+        )
+
+    def test_language_switcher_not_default_view_method(self):
+        self.assertNotEqual(
+            'language-switcher',
+            self.portal.portal_types['Plone Site'].default_view
+        )


### PR DESCRIPTION
When uninstalling plone.app.multilingual, remove `language-switcher` from Plone Site's available view_methods and also from default_view, if present.

See https://community.plone.org/t/have-a-just-destroyed-my-site-plone-app-multilingual-problem/6173 for some context.

I also added a uninstall test to show that it behaves correctly.