### PR TITLE
Fixed tests now that Catalan has translated 'assets' into 'recursos'.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed tests now that Catalan has translated 'assets' into 'recursos'.
+  [maurits]
 
 
 5.2.0 (2018-04-04)
@@ -37,7 +38,7 @@ Bug fixes:
   [erral]
 
 - Fix i18n markup of the viewlet shown in the translation creation view.
-  [erral] 
+  [erral]
 
 
 5.1.4 (2018-02-02)

--- a/src/plone/app/multilingual/tests/test_lrf.py
+++ b/src/plone/app/multilingual/tests/test_lrf.py
@@ -29,7 +29,7 @@ class TestLanguageRootFolder(unittest.TestCase):
 
         # Check shared document is there
         self.assertEqual(self.portal.en.assets['test-document'],
-                         self.portal.ca.assets['test-document'])
+                         self.portal.ca.recursos['test-document'])
         self.assertEqual(self.portal.en.assets['test-document'],
                          self.portal.es.recursos['test-document'])
 
@@ -38,7 +38,7 @@ class TestLanguageRootFolder(unittest.TestCase):
         self.portal.en.assets.manage_delObjects('test-document')
 
         # Check that it is not available in LRFs
-        self.assertNotIn('test-document', self.portal.ca.assets.objectIds())
+        self.assertNotIn('test-document', self.portal.ca.recursos.objectIds())
         self.assertNotIn('test-document', self.portal.es.recursos.objectIds())
 
     def test_shared_content_indexing(self):
@@ -66,7 +66,7 @@ class TestLanguageRootFolder(unittest.TestCase):
             self.portal.assets, 'Document', title=u"Test document")
 
         root_uuid = IUUID(self.portal.assets['test-document'])
-        shared_uuid = IUUID(self.portal.ca.assets['test-document'])
+        shared_uuid = IUUID(self.portal.ca.recursos['test-document'])
 
         self.assertEqual('{0:s}-ca'.format(root_uuid), shared_uuid)
 
@@ -80,7 +80,7 @@ class TestLanguageRootFolder(unittest.TestCase):
 
         # Check that ghost is ghost
         self.assertTrue(
-            is_language_independent(self.portal.ca.assets['test-document']))
+            is_language_independent(self.portal.ca.recursos['test-document']))
 
         # Check is in the catalog
         brains = self.portal.portal_catalog.searchResults(UID=uuid)
@@ -90,7 +90,7 @@ class TestLanguageRootFolder(unittest.TestCase):
         brains = self.portal.portal_catalog.searchResults(
             UID='{0:s}-ca'.format(uuid))
         self.assertEqual(len(brains), 1)
-        self.assertEqual(brains[0].getPath(), '/plone/ca/assets/test-document')
+        self.assertEqual(brains[0].getPath(), '/plone/ca/recursos/test-document')
 
         brains = self.portal.portal_catalog.searchResults(
             UID='{0:s}-es'.format(uuid))
@@ -99,7 +99,7 @@ class TestLanguageRootFolder(unittest.TestCase):
 
         # MOVE!
         moved = multilingualMoveObject(
-            self.portal.ca.assets['test-document'], 'ca')
+            self.portal.ca.recursos['test-document'], 'ca')
 
         # Check that the old and the new uuid are the same
         moved_uuid = IUUID(self.portal.ca['test-document'])

--- a/src/plone/app/multilingual/tests/test_menu.py
+++ b/src/plone/app/multilingual/tests/test_menu.py
@@ -32,7 +32,8 @@ class TestMenu(unittest.TestCase):
 
     def test_menu_is_visible(self):
         self.browser.open(self.a_ca.absolute_url())
-        self.assertIn('Translate', self.browser.contents)
+        # 'Translate' in Catalan:
+        self.assertIn('Tradueix', self.browser.contents)
 
     def test_menu_contains_translatable_entries(self):
         self.browser.open(self.a_ca.absolute_url())

--- a/src/plone/app/multilingual/tests/test_sitemap.py
+++ b/src/plone/app/multilingual/tests/test_sitemap.py
@@ -59,7 +59,7 @@ class TestSitemap(unittest.TestCase):
         self.assertIn('<loc>http://nohost/plone/en/test-document</loc>', xml)
         self.assertIn('<loc>http://nohost/plone/es/test-document</loc>', xml)
 
-        self.assertIn('<loc>http://nohost/plone/ca/assets/test-document</loc>', xml)
+        self.assertIn('<loc>http://nohost/plone/ca/recursos/test-document</loc>', xml)
         self.assertIn('<loc>http://nohost/plone/en/assets/test-document</loc>', xml)
         self.assertIn('<loc>http://nohost/plone/es/recursos/test-document</loc>', xml)
 
@@ -74,6 +74,6 @@ class TestSitemap(unittest.TestCase):
         self.assertNotIn('<loc>http://nohost/plone/en/test-document</loc>', xml)  # noqa
         self.assertIn('<loc>http://nohost/plone/es/test-document</loc>', xml)
 
-        self.assertNotIn('<loc>http://nohost/plone/ca/assets/test-document</loc>', xml)
+        self.assertNotIn('<loc>http://nohost/plone/ca/recursos/test-document</loc>', xml)
         self.assertNotIn('<loc>http://nohost/plone/en/assets/test-document</loc>', xml)
         self.assertIn('<loc>http://nohost/plone/es/recursos/test-document</loc>', xml)

--- a/src/plone/app/multilingual/tests/test_subscribers.py
+++ b/src/plone/app/multilingual/tests/test_subscribers.py
@@ -76,7 +76,7 @@ class TestSubscribers(unittest.TestCase):
 
         # Test a paste into a subfolder to be ultra cautious
         ca_assets_subfolder = createContentInContainer(
-            self.portal['ca']['assets'], 'Folder', title=u"A Folder")
+            self.portal['ca']['recursos'], 'Folder', title=u"A Folder")
 
         subfolder_name = ca_assets_subfolder.id
 
@@ -84,7 +84,7 @@ class TestSubscribers(unittest.TestCase):
         ca_assets_subfolder.manage_pasteObjects(id_)
 
         # Get both assets folders afresh
-        ca_assets_subfolder = self.portal['ca']['assets'][subfolder_name]
+        ca_assets_subfolder = self.portal['ca']['recursos'][subfolder_name]
         en_assets_subfolder = self.portal['en']['assets'][subfolder_name]
 
         # Check it is in both folder listings
@@ -119,14 +119,14 @@ class TestSubscribers(unittest.TestCase):
 
         # Test a paste into a subfolder to be ultra cautious
         ca_assets_subfolder = createContentInContainer(
-            self.portal['ca']['assets'], 'Folder', title=u"A Folder")
+            self.portal['ca']['recursos'], 'Folder', title=u"A Folder")
 
         subfolder_name = ca_assets_subfolder.id
         id_ = self.portal['ca'].manage_copyObjects(a_ca.id)
         ca_assets_subfolder.manage_pasteObjects(id_)
 
         # Get both assets folders afresh
-        ca_assets_subfolder = self.portal['ca']['assets'][subfolder_name]
+        ca_assets_subfolder = self.portal['ca']['recursos'][subfolder_name]
         en_assets_subfolder = self.portal['en']['assets'][subfolder_name]
 
         # Check it is in both folder listings


### PR DESCRIPTION
This means a Catalan folder in a multilingual site will not have a folder with id `assets`, but with id `recursos`.
For a similar fix in Spanish last year, see 0be09c3897cfbb7b4d6c3fa57e5d3febbcbdb72e

Jenkins was broken since the merge of https://github.com/collective/plone.app.locales/pull/229, which contains the new translation, and no one can be blamed for that: more translations are good. Also, it was not obvious that this was the cause: Jenkins didn't point a finger.