### PR TITLE
[2.x] Fix translation group handling for Archetypes content.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New features:
 
 Bug fixes:
 
+- Pass the source object's UUID when adding a new translation for
+  archetypes content.
+  [witsch]
+
 - Fix language alternate viewlet #153 [erral, petschki]
 
 - Fix error in folder_paste script when you copy/paste AT folder,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'z3c.relationfield',
     ],
     extras_require={
-        'archetypes': ['archetypes.multilingual < 3.0'],
+        'archetypes': ['archetypes.multilingual >= 2.0.1dev, < 3.0'],
         'test': [
             'plone.app.testing[robot]>=4.2.2',
             'plone.app.robotframework',

--- a/src/plone/app/multilingual/browser/add.py
+++ b/src/plone/app/multilingual/browser/add.py
@@ -71,7 +71,8 @@ class AddViewTraverser(object):
         if not IDexterityContent.providedBy(source):
             # we are not on DX content, assume AT
             baseUrl = self.context.absolute_url()
-            url = '%s/@@add_at_translation?uid=%s' % (baseUrl, name)
+            url = '%s/@@add_at_translation?type=%s&uid=%s' % (
+                baseUrl, source.portal_type, name)
             return self.request.response.redirect(url)
 
         # set the self.context to the place where it should be stored

--- a/src/plone/app/multilingual/browser/add.py
+++ b/src/plone/app/multilingual/browser/add.py
@@ -71,7 +71,7 @@ class AddViewTraverser(object):
         if not IDexterityContent.providedBy(source):
             # we are not on DX content, assume AT
             baseUrl = self.context.absolute_url()
-            url = '%s/@@add_at_translation?type=%s' % (baseUrl, source.portal_type)
+            url = '%s/@@add_at_translation?uid=%s' % (baseUrl, name)
             return self.request.response.redirect(url)
 
         # set the self.context to the place where it should be stored


### PR DESCRIPTION
This is a supplemental change required by https://github.com/plone/archetypes.multilingual/pull/24, attempting to fix https://github.com/plone/archetypes.multilingual/issues/18 and https://github.com/plone/archetypes.multilingual/issues/13.

Please see the explanation in c7d96f1f4fdfe82b3d6e202bd9aadb284ceb32f0 as well as https://github.com/plone/archetypes.multilingual/pull/24 for more info.