### PR TITLE
Default to a 4K x 4K browser window in Robot tests

### DIFF
--- a/news/349.bugfix
+++ b/news/349.bugfix
@@ -1,0 +1,3 @@
+- Use the shared 'Plone test setup' and 'Plone test teardown' keywords in Robot
+  tests.
+  [Rotonen]

--- a/src/plone/app/multilingual/tests/robot/test_add_translation.robot
+++ b/src/plone/app/multilingual/tests/robot/test_add_translation.robot
@@ -1,13 +1,14 @@
 *** Settings ***
 
-Resource  plone/app/robotframework/selenium.robot
 Resource  plone/app/robotframework/keywords.robot
+Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 Resource  Products/CMFPlone/tests/robot/keywords.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Test Setup  Setup test browser
-Test Teardown  Close all browsers
+Test Setup  Run Keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 *** Test Cases ***
 

--- a/src/plone/app/multilingual/tests/robot/test_schemaeditor.robot
+++ b/src/plone/app/multilingual/tests/robot/test_schemaeditor.robot
@@ -1,12 +1,13 @@
 *** Settings ***
 
-Resource  plone/app/robotframework/selenium.robot
 Resource  plone/app/robotframework/keywords.robot
+Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Test Setup  Open test browser
-Test Teardown  Close all browsers
+Test Setup  Run Keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 
 *** Test Cases ***

--- a/src/plone/app/multilingual/tests/robot/test_translate_content.robot
+++ b/src/plone/app/multilingual/tests/robot/test_translate_content.robot
@@ -1,12 +1,13 @@
 *** Settings ***
 
-Resource  plone/app/robotframework/selenium.robot
 Resource  plone/app/robotframework/keywords.robot
+Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Test Setup  Open test browser
-Test Teardown  Close all browsers
+Test Setup  Run Keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 
 *** Test Cases ***


### PR DESCRIPTION
I'm in the process of trying to unify Robot test setups and teardowns. This is a part of that effort.

Also re-enabled two previously disabled Robot tests.

In tandem with https://github.com/plone/plone.app.robotframework/pull/110
Closes https://github.com/plone/plone.app.multilingual/issues/349