### PR TITLE
Fix "Insufficient Privileges" error when adding translations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix "Insufficient Privileges" error when adding translations.
+  [witsch]
 
 
 2.0.4 (2019-02-12)

--- a/src/plone/app/multilingual/browser/add.py
+++ b/src/plone/app/multilingual/browser/add.py
@@ -70,10 +70,11 @@ class AddViewTraverser(object):
         # XXX: register this adapter on dx container and a second one for AT
         if not IDexterityContent.providedBy(source):
             # we are not on DX content, assume AT
-            baseUrl = self.context.absolute_url()
-            url = '%s/@@add_at_translation?type=%s&uid=%s' % (
-                baseUrl, source.portal_type, name)
-            return self.request.response.redirect(url)
+            self.request.set('type', source.portal_type)
+            self.request.set('uid', name)
+            view = queryMultiAdapter(
+                (self.context, self.request), name="add_at_translation")
+            return view.__of__(self.context)
 
         # set the self.context to the place where it should be stored
         if not IFolderish.providedBy(self.context):


### PR DESCRIPTION
In some cases, e.g. when the target folder is "private", the traversal does not work well with the URL redirection. Luckily, looking up the `add_at_translation` view and using it directly fixes this. Kudos to Mathias Leimgruber (@maethu) for [suggesting this](https://stackoverflow.com/q/23109624).

The underlying problem seems to be the two `hasattr` calls in [`BaseRequest.traverse()`](https://github.com/zopefoundation/Zope/blob/2.13.28/src/ZPublisher/BaseRequest.py#L509), although `getRoles` a few lines below apparently works correctly.  In any case, if the current user has no access to the target folder, return the redirection URL as a string causes the following error:
```python
Traceback (innermost last):
  Module ZPublisher.Publish, line 127, in publish
  Module ZPublisher.BaseRequest, line 623, in traverse
  Module ZPublisher.HTTPResponse, line 756, in unauthorized
Unauthorized: You are not authorized to access this resource.
No Authorization header found.
```