### PR TITLE
wrong check for default addview in addtranslation traverser

### DIFF
--- a/news/355.bugfix
+++ b/news/355.bugfix
@@ -1,0 +1,2 @@
+wrong check for default addview in addtranslation traverser
+[mauro]

--- a/src/plone/app/multilingual/browser/add.py
+++ b/src/plone/app/multilingual/browser/add.py
@@ -99,7 +99,7 @@ class AddViewTraverser(object):
             )
         if add_view is None:
             add_view = queryMultiAdapter((self.context, self.request, ti))
-            if add_view is not None:
+            if add_view is None:
                 raise TraversalError(self.context, name)
 
         add_view.__name__ = ti.factory


### PR DESCRIPTION
Without using babel_view, in the traverser ++addtranslation++  there is a wrong check for default addview.

Probably the same bug had been reported here, years ago, https://github.com/plone/Products.CMFPlone/issues/599