### PR TITLE
New events and cleanup

### DIFF
--- a/news/256.bugfix
+++ b/news/256.bugfix
@@ -1,0 +1,5 @@
+Remove deprecation warnings in tests.
+Increase readability
+Add code comments.
+Remove superfluos reindex of "Language" in manager.
+[jensens]

--- a/news/256.feature
+++ b/news/256.feature
@@ -1,0 +1,3 @@
+Add low level events and notifies:
+on register, update and remove of a translation to a translation groups.
+[jensens]

--- a/src/plone/app/multilingual/events.py
+++ b/src/plone/app/multilingual/events.py
@@ -19,6 +19,39 @@ class IObjectTranslatedEvent(IObjectEvent):
     language = Attribute("Target language.")
 
 
+class ITranslationRegisteredEvent(IObjectEvent):
+    """Sent after a new translation was registered.
+
+    This is meant to be notified on low-level manager level only.
+    """
+
+    object = Attribute("The base object.")
+    target = Attribute("The translated object.")
+    language = Attribute("The language of the translated obejct.")
+
+
+class ITranslationUpdatedEvent(IObjectEvent):
+    """Sent after an translation was moved to point to a different object
+
+    This is meant to be notified on low-level manager level only.
+    """
+
+    object = Attribute("The base object.")
+    old_object = Attribute("The old translation, now orphaned.")
+    language = Attribute("The language of the objects.")
+
+
+class ITranslationRemovedEvent(IObjectEvent):
+    """Sent after an translation was removed.
+
+    This is meant to be notified on low-level manager level only.
+    """
+
+    object = Attribute("The base object.")
+    old_object = Attribute("The old translation, now orphaned.")
+    language = Attribute("The language of the objects.")
+
+
 @implementer(IObjectWillBeTranslatedEvent)
 class ObjectWillBeTranslatedEvent(object):
     """Sent before an object is translated."""
@@ -35,4 +68,37 @@ class ObjectTranslatedEvent(object):
     def __init__(self, context, target, language):
         self.object = context
         self.target = target
+        self.language = language
+
+
+@implementer(ITranslationRegisteredEvent)
+class TranslationRegisteredEvent(object):
+    """Sent after a new translation was registered.
+    """
+
+    def __init__(self, context, target, language):
+        self.object = context
+        self.target = target
+        self.language = language
+
+
+@implementer(ITranslationUpdatedEvent)
+class TranslationUpdatedEvent(object):
+    """Sent after an translation was moved to point to a different object
+    """
+
+    def __init__(self, context, old_object, language):
+        self.object = context
+        self.old_object = old_object
+        self.language = language
+
+
+@implementer(ITranslationRemovedEvent)
+class TranslationRemovedEvent(object):
+    """Sent after an translation was moved to point to a different object
+    """
+
+    def __init__(self, context, old_object, language):
+        self.object = context
+        self.old_object = old_object
         self.language = language

--- a/src/plone/app/multilingual/indexer.py
+++ b/src/plone/app/multilingual/indexer.py
@@ -12,5 +12,4 @@ def itgIndexer(obj):
 
 @indexer(ITranslatable)
 def LanguageIndexer(object, **kw):
-    language = ILanguage(object).get_language()
-    return language
+    return ILanguage(object).get_language()

--- a/src/plone/app/multilingual/itg.py
+++ b/src/plone/app/multilingual/itg.py
@@ -40,9 +40,11 @@ class MutableAttributeTG(object):
 @adapter(ITranslatable, IObjectCreatedEvent)
 def addAttributeTG(obj, event):
 
-    if not IObjectCopiedEvent.providedBy(event):
-        if getattr(aq_base(obj), ATTRIBUTE_NAME, None):
-            return  # defensive: keep existing TG on non-copy create
+    if (
+        not IObjectCopiedEvent.providedBy(event)
+        and getattr(aq_base(obj), ATTRIBUTE_NAME, None)
+    ):
+        return  # defensive: keep existing TG on non-copy create
 
     generator = queryUtility(IUUIDGenerator)
     if generator is None:

--- a/src/plone/app/multilingual/tests/test_api.py
+++ b/src/plone/app/multilingual/tests/test_api.py
@@ -236,7 +236,7 @@ class TestLanguageRootFolderAPI(unittest.TestCase):
         id_a_ca = ITranslationManager(a_ca).query_canonical()
         id_another_es = ITranslationManager(another_es).query_canonical()
 
-        self.assertNotEquals(id_another_es, id_a_ca)
+        self.assertNotEqual(id_another_es, id_a_ca)
         self.assertTrue(isinstance(id_another_es, str))
         self.assertTrue(isinstance(id_a_ca, str))
 

--- a/src/plone/app/multilingual/tests/test_selector.py
+++ b/src/plone/app/multilingual/tests/test_selector.py
@@ -84,7 +84,7 @@ class TestLanguageSelectorBasics(unittest.TestCase):
         selector_adapter.update()
         selector_adapter_languages = selector_adapter.languages()
 
-        self.assertNotEquals(
+        self.assertNotEqual(
             selector_adapter_languages, selector_viewlet_languages
         )
 


### PR DESCRIPTION
New low level events: 
- ITranslationRegisteredEvent
- ITranslationRemovedEvent
- ITranslationUpdatedEvent

-> fired when TG is modified

Cleanup:
- remove deprecation warnings in tests
- increase readability
- add comments
- remove superfluos reindex of "Language" in manager.