### PR TITLE
Marked robot test for adding translation as unstable. [5.2.x]

### DIFF
--- a/news/365.bugfix
+++ b/news/365.bugfix
@@ -1,0 +1,4 @@
+Marked robot test for adding translation as unstable.
+On Jenkins it has not succeeded on Plone 5.1 for long, and is unstable on 5.2.
+Locally the test passes fine on Chrome and Firefox.
+[maurits]

--- a/src/plone/app/multilingual/tests/robot/test_add_translation.robot
+++ b/src/plone/app/multilingual/tests/robot/test_add_translation.robot
@@ -12,6 +12,7 @@ Test Teardown  Close all browsers
 *** Test Cases ***
 
 Scenario: As an editor I can add new translation
+    [Tags]  unstable
     Given a site owner
       and a document in English
       and a document in Catalan


### PR DESCRIPTION
On Jenkins it has not succeeded on Plone 5.1 for long, and is unstable on 5.2.
Locally the test passes fine on Chrome and Firefox.

I tried getting the test to pass on Jenkins, but that failed.
See https://github.com/plone/plone.app.multilingual/pull/366

This PR is for branch 5.2.x (Plone 5.1)