### PR TITLE
Marked robot test for adding translation as unstable. [master]

### DIFF
--- a/news/365.bugfix
+++ b/news/365.bugfix
@@ -1,0 +1,4 @@
+Marked robot test for adding translation as unstable.
+On Jenkins it has not succeeded on Plone 5.1 for long, and is unstable on 5.2.
+Locally the test passes fine on Chrome and Firefox.
+[maurits]

--- a/src/plone/app/multilingual/tests/robot/test_add_translation.robot
+++ b/src/plone/app/multilingual/tests/robot/test_add_translation.robot
@@ -13,6 +13,7 @@ Test Teardown  Run keywords  Plone test teardown
 *** Test Cases ***
 
 Scenario: As an editor I can add new translation
+    [Tags]  unstable
     Given a site owner
       and a document in English
       and a document in Catalan


### PR DESCRIPTION
On Jenkins it has not succeeded on Plone 5.1 for long, and is unstable on 5.2.
Locally the test passes fine on Chrome and Firefox.

I tried getting the test to pass on Jenkins, but that failed.
See https://github.com/plone/plone.app.multilingual/pull/366