### PR TITLE
Retry failing robot tests twice.

### DIFF
--- a/news/365.bugfix
+++ b/news/365.bugfix
@@ -1,0 +1,3 @@
+Retry failing robot tests twice.
+Some are unstable.
+[maurits]

--- a/src/plone/app/multilingual/tests/test_robot.py
+++ b/src/plone/app/multilingual/tests/test_robot.py
@@ -17,7 +17,7 @@ def test_suite():
     suite.level = ROBOT_TEST_LEVEL
     suite.addTests([
         layered(
-            robotsuite.RobotTestSuite('robot', noncritical=['unstable']),
+            robotsuite.RobotTestSuite('robot', noncritical=['unstable'], retry_count=2),
             layer=PAM_ROBOT_TESTING),
     ])
     return suite


### PR DESCRIPTION
Some are unstable.
This uses a new feature from robotsuite 2.2.1.
On earlier versions, this change has no effect.