### PR TITLE
Fix AttributeError when using multilingual switcher on neutral content. [1.x]

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,8 @@ New features:
 
 Bug fixes:
 
+- Fix AttributeError when using the language switcher on content in the shared folder.  [maurits]
+
 - Fix language alternate viewlet #153 [erral]
 
 

--- a/src/plone/app/multilingual/browser/helper_views.py
+++ b/src/plone/app/multilingual/browser/helper_views.py
@@ -246,6 +246,9 @@ class not_translated_yet(BrowserView):
             lang_code = self.request.get('set_language')
         else:
             lang_code = lang
+        if not lang_code:
+            # For shared content, lang_code is an empty string.
+            return ''
         util = getUtility(IContentLanguageAvailability)
         data = util.getLanguages(True)
         lang_info = data.get(lang_code)


### PR DESCRIPTION
I saw this in a client site, but see the same in a fresh Plone 4.3 site with plone.app.multilingual 1.x.

- In the Settings, go to the Policies, and select to show a user dialog with information about the available translations.
- Go to the shared folder.
- Click one of the links in the multilingual switcher.
- The not_translated_yet view is rendered, which finds one catalog brain for this translation group.
- It tries to get the language name based on the language code.
- This fails because the langauge code is an empty string.

```
...
  Module zope.tales.tales, line 696, in evaluate
   - URL: /home/plone/production/eggs/plone.app.multilingual-1.2.3-py2.7.egg/plone/app/multilingual/browser/templates/not_translated_yet.pt
   - Line 34, Column 16
   - Expression: <PythonExpr (view.language_name(code))>
   - Names:
      {'args': (),
       'container': <PloneSite at /air>,
       'context': <PloneSite at /air>,
       'default': <object object at 0x7fb2b6428560>,
       'here': <PloneSite at /air>,
       'loop': {},
       'nothing': None,
       'options': {},
       'repeat': <Products.PageTemplates.Expressions.SafeMapping object at 0x7fb28c25e368>,
       'request': <HTTPRequest, URL=http://127.0.01:8080/Plone/not_translated_yet/cd6052781ff44a31bc6c477c02546278>,
       'root': <Application at >,
       'template': <Products.Five.browser.pagetemplatefile.ViewPageTemplateFile object at 0x7fb29704fbd0>,
       'traverse_subpath': [],
       'user': <SpecialUser 'Anonymous User'>,
       'view': <Products.Five.metaclass.not_translated_yet object at 0x7fb28e3704d0>,
       'views': <Products.Five.browser.pagetemplatefile.ViewMapper object at 0x7fb28c19ed50>}
  Module zope.tales.pythonexpr, line 59, in __call__
   - __traceback_info__: (view.language_name(code))
  Module <string>, line 1, in <module>
  Module plone.app.multilingual.browser.helper_views, line 252, in language_name
AttributeError: 'NoneType' object has no attribute 'get'
```

This PR fixes the immediate error, and results in a proper rendering of the not_yet_translated page.
It is not pretty, but at least it is not an error page:

![Screenshot 2020-03-16 at 16 42 56](https://user-images.githubusercontent.com/210587/76775443-a7297c00-67a5-11ea-8689-78e3dd9ba679.png)

Additionally, we should perhaps not show the multilingual switcher at all in neutral content.
But this is ancient plone.app.multilingual 1.x, so let's not change it much.

BTW, the test buildout is pretty unmaintained and broken, which is not surprising: the last change was in June 2017. Locally it worked after copying a fresher `bootstrap.py`, commenting out most of the buildout, and adding version pins for the other multilingual packages. But I don't want to bother with that.  `bin/test` at least runs, when you ignore the robot tests.
