### PR TITLE
move metadata to setup.cfg in order to avoid encoding problems in CHANGES.rst

### DIFF
--- a/news/372.bugfix
+++ b/news/372.bugfix
@@ -1,0 +1,2 @@
+Move metadata to setup.cfg in order to avoid encoding problems in CHANGES.rst running Plone 6.0 on Python 3.6, see #372.
+[jensens]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,28 @@
+[metadata]
+version = 5.5.2.dev0
+name = plone.app.multilingual
+description = Multilingual Plone Content package
+long_description = file: README.rst, CREDITS.rst, CHANGES.rst
+classifiers=
+    Development Status :: 5 - Production/Stable
+    Framework :: Plone
+    Framework :: Plone :: 5.2
+    Framework :: Plone :: Core
+    License :: OSI Approved :: GNU General Public License (GPL)
+    Programming Language :: Python
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Software Development :: Libraries :: Python Modules
+url = https://github.com/plone/plone.app.multilingual
+license = GPL
+keywords = language, multilingual, content
+author = Ramon Navarro, Victor Fernandez de Alba, awello et al
+author_email = r.navarro@iskra.cat
+maintainer = Plone Foundation
+maintainer_email = releasemanager@plone.org
+
 [check-manifest]
 ignore =
     *.cfg

--- a/setup.py
+++ b/setup.py
@@ -2,39 +2,9 @@
 from setuptools import find_packages
 from setuptools import setup
 
-import os
-
-
-version = '5.5.2.dev0'
 
 setup(
-    name='plone.app.multilingual',
-    version=version,
-    description='Multilingual Plone UI package, enables maintenance of '
-                'translations for both Dexterity types and Archetypes',
-    long_description='\n\n'.join([
-        open('README.rst').read(),
-        open(os.path.join('docs', 'CREDITS.txt')).read(),
-        open('CHANGES.rst').read(),
-    ]),
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Framework :: Plone',
-        'Framework :: Plone :: 5.2',
-        'Framework :: Plone :: Core',
-        'License :: OSI Approved :: GNU General Public License (GPL)',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-    ],
-    url='https://github.com/plone/plone.app.multilingual',
-    license='GPL',
-    keywords='language multilingual content',
-    author='Ramon Navarro, Victor Fernandez de Alba, awello et al',
-    author_email='r.navarro@iskra.cat',
+    # metadata in setup.cfg
     packages=find_packages('src'),
     package_dir={'': 'src'},
     namespace_packages=['plone', 'plone.app'],


### PR DESCRIPTION
fixes in Plone 6.0 on Python 3.6 occuring:

```
Develop: '/home/jenkins/workspace/pull-request-5.2-3.6/src/plone.app.multilingual'
Traceback (most recent call last):
  File "/tmp/tmpdjmk1ik3", line 14, in <module>
    exec(compile(f.read(), '/home/jenkins/workspace/pull-request-5.2-3.6/src/plone.app.multilingual/setup.py', 'exec'))
  File "/home/jenkins/workspace/pull-request-5.2-3.6/src/plone.app.multilingual/setup.py", line 18, in <module>
    open('CHANGES.rst').read(),
  File "/home/jenkins/shiningpanda/jobs/8809464e/virtualenvs/0dd3bfc1/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 3297: ordinal not in range(128)
While:
  Installing.
  Processing develop directory '/home/jenkins/workspace/pull-request-5.2-3.6/src/plone.app.multilingual'.

```