### PR TITLE
Fix three deprecation warnings.

### DIFF
--- a/news/3130.bugfix
+++ b/news/3130.bugfix
@@ -1,4 +1,5 @@
 Fixed deprecation warning for ComponentLookupError.
 Fixed deprecation warning for ILanguageSchema, depend on ``plone.i18n`` 4.0.4.
 Fixed deprecation warning for IObjectEvent from zope.component.
+Fixed deprecation warning for zope.site.hooks.
 [maurits]

--- a/news/3130.bugfix
+++ b/news/3130.bugfix
@@ -1,3 +1,4 @@
 Fixed deprecation warning for ComponentLookupError.
 Fixed deprecation warning for ILanguageSchema, depend on ``plone.i18n`` 4.0.4.
+Fixed deprecation warning for IObjectEvent from zope.component.
 [maurits]

--- a/news/3130.bugfix
+++ b/news/3130.bugfix
@@ -1,2 +1,3 @@
 Fixed deprecation warning for ComponentLookupError.
+Fixed deprecation warning for ILanguageSchema, depend on ``plone.i18n`` 4.0.4.
 [maurits]

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
+        'plone.i18n>=4.0.4',
         'Products.CMFPlone>=5.2rc4',
         'setuptools',
         'six',

--- a/src/plone/app/multilingual/events.py
+++ b/src/plone/app/multilingual/events.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from zope.component.interfaces import IObjectEvent
 from zope.interface import Attribute
 from zope.interface import implementer
+from zope.interface.interfaces import IObjectEvent
 
 
 class IObjectWillBeTranslatedEvent(IObjectEvent):

--- a/src/plone/app/multilingual/interfaces.py
+++ b/src/plone/app/multilingual/interfaces.py
@@ -1,18 +1,13 @@
 # -*- coding: utf-8 -*-
 from plone.app.multilingual import _
 from plone.app.z3cform.interfaces import IPloneFormLayer
+from plone.i18n.interfaces import ILanguageSchema
 from plone.supermodel import model
 from zope import schema
 from zope.interface import Attribute
 from zope.interface import Interface
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
-
-try:
-    from plone.i18n.interfaces import ILanguageSchema
-except ImportError:
-    # BBB for Plone 5.1, remove with Plone 6
-    from Products.CMFPlone.interfaces import ILanguageSchema
 
 
 # CONSTANTS

--- a/src/plone/app/multilingual/manager.py
+++ b/src/plone/app/multilingual/manager.py
@@ -16,9 +16,9 @@ from plone.uuid.handlers import addAttributeUUID
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import ILanguage
+from zope.component.hooks import getSite
 from zope.event import notify
 from zope.interface import implementer
-from zope.site.hooks import getSite
 
 
 @implementer(ITranslationManager)

--- a/src/plone/app/multilingual/tests/test_helper_views.py
+++ b/src/plone/app/multilingual/tests/test_helper_views.py
@@ -7,10 +7,10 @@ from plone.app.multilingual.testing import PAM_FUNCTIONAL_TESTING
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.dexterity.utils import createContentInContainer
+from plone.i18n.interfaces import ILanguageSchema
 from plone.registry.interfaces import IRegistry
 from plone.testing.z2 import Browser
 from Products.CMFPlone.interfaces import ILanguage
-from Products.CMFPlone.interfaces import ILanguageSchema
 from zope.component import getUtility
 from zope.interface import alsoProvides
 


### PR DESCRIPTION
ILanguageSchema, IObjectEvent, zope.site.hooks.

Added `plone.i18n>=4.0.4` as dependency for `ILanguageSchema`. In practice we were already depending on this, just not officially in `setup.py`.
Note: master branch is for Plone 5.2+, so we don't need conditional imports.