### PR TITLE
fix deleting items with broken relation in languageindependent field

### DIFF
--- a/news/390.bugfix
+++ b/news/390.bugfix
@@ -1,0 +1,2 @@
+Fix deleting items with broken relation in languageindependent field
+[pbauer]

--- a/src/plone/app/multilingual/dx/cloner.py
+++ b/src/plone/app/multilingual/dx/cloner.py
@@ -49,6 +49,9 @@ class LanguageIndependentFieldsManager(object):
         return False
 
     def copy_relation(self, relation_value, target_language):
+        if not relation_value or relation_value.isBroken():
+            return
+
         obj = relation_value.to_object
         intids = getUtility(IIntIds)
         translation = ITranslationManager(obj).get_translation(target_language)
@@ -62,20 +65,21 @@ class LanguageIndependentFieldsManager(object):
 
         target_language = queryAdapter(translation, ILanguage).get_language()
 
-        def relation_copier(rel, lang=target_language, fun=self.copy_relation):
-            return fun(rel, lang)
-
         for schema in iterSchemata(self.context):
             for field_name in schema:
                 if ILanguageIndependentField.providedBy(schema[field_name]):
                     value = getattr(schema(self.context), field_name, _marker)
-
                     if value == _marker:
                         continue
                     elif IRelationValue.providedBy(value):
                         value = self.copy_relation(value, target_language)
                     elif IRelationList.providedBy(schema[field_name]):
-                        value = list(map(relation_copier, value or []))
+                        new_value = []
+                        for relation in value:
+                            copied_relation = self.copy_relation(relation, target_language)
+                            if copied_relation:
+                                new_value.append(copied_relation)
+                        value = new_value
 
                     doomed = True
                     setattr(schema(translation),

--- a/src/plone/app/multilingual/dx/cloner.py
+++ b/src/plone/app/multilingual/dx/cloner.py
@@ -74,12 +74,15 @@ class LanguageIndependentFieldsManager(object):
                     elif IRelationValue.providedBy(value):
                         value = self.copy_relation(value, target_language)
                     elif IRelationList.providedBy(schema[field_name]):
-                        new_value = []
-                        for relation in value:
-                            copied_relation = self.copy_relation(relation, target_language)
-                            if copied_relation:
-                                new_value.append(copied_relation)
-                        value = new_value
+                        if not value:
+                            value = []
+                        else:
+                            new_value = []
+                            for relation in value:
+                                copied_relation = self.copy_relation(relation, target_language)
+                                if copied_relation:
+                                    new_value.append(copied_relation)
+                            value = new_value
 
                     doomed = True
                     setattr(schema(translation),


### PR DESCRIPTION
Fixes this traceback: 

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 167, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 376, in publish_module
  Module ZPublisher.WSGIPublisher, line 271, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module Products.PDBDebugMode.wsgi_runcall, line 60, in pdb_runcall
  Module z3c.form.form, line 233, in __call__
  Module z3c.form.form, line 228, in update
  Module plone.app.z3cform.csrf, line 22, in execute
  Module z3c.form.action, line 98, in execute
  Module z3c.form.button, line 315, in __call__
  Module z3c.form.button, line 170, in __call__
  Module plone.app.content.browser.actions, line 78, in handle_delete
  Module plone.dexterity.content, line 798, in manage_delObjects
  Module OFS.ObjectManager, line 558, in manage_delObjects
  Module Products.BTreeFolder2.BTreeFolder2, line 485, in _delObject
  Module zope.event, line 32, in notify
  Module zope.component.event, line 27, in dispatch
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 619, in subscribers
  Module zope.component.event, line 36, in objectEventNotify
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 619, in subscribers
  Module five.intid.intid, line 127, in removeIntIdSubscriber
  Module zope.event, line 32, in notify
  Module zope.component.event, line 27, in dispatch
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 619, in subscribers
  Module z3c.relationfield.event, line 113, in breakRelations
  Module zope.event, line 32, in notify
  Module zope.component.event, line 27, in dispatch
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 619, in subscribers
  Module zope.component.event, line 36, in objectEventNotify
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 619, in subscribers
  Module plone.app.multilingual.dx.subscriber, line 49, in __call__
  Module plone.app.multilingual.dx.subscriber, line 87, in handle_modified
  Module plone.app.multilingual.dx.cloner, line 85, in copy_fields
  Module plone.app.multilingual.dx.cloner, line 58, in copy_relation
TypeError: ('Could not adapt', None, <InterfaceClass plone.app.multilingual.interfaces.ITranslationManager>)
```