### PR TITLE
fix interface of settings according to CMFPlone

### DIFF
--- a/news/394.bugfix
+++ b/news/394.bugfix
@@ -1,0 +1,2 @@
+In CMFPlone the ILanguage schema was moved to plone.i18n and is referenced as such there, here the change was missing.
+[jensens]

--- a/src/plone/app/multilingual/profiles/default/registry.xml
+++ b/src/plone/app/multilingual/profiles/default/registry.xml
@@ -14,7 +14,7 @@
     <value key="contains_objects" purge="false"><element>LIF</element></value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.ILanguageSchema" prefix="plone">
+  <records interface="plone.i18n.interfaces.ILanguageSchema" prefix="plone">
     <value key="use_cookie_negotiation">True</value>
     <value key="use_request_negotiation">False</value>
     <value key="use_content_negotiation">True</value>


### PR DESCRIPTION
In  CMFPlone this was moved to plone.i18n and is referenced as such there, here the change was missing.