### PR TITLE
Update view methods and layouts from LIF/LRF FTI and objects

### DIFF
--- a/news/1001.bugfix
+++ b/news/1001.bugfix
@@ -1,0 +1,3 @@
+Update old view methods and layouts from LIF/LRF type definitions and instances.
+For example, in Plone 6 ``folder_summary_view`` is no longer available: use ``summary_view`` instead.
+[maurits]

--- a/src/plone/app/multilingual/profiles/default/metadata.xml
+++ b/src/plone/app/multilingual/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1000</version>
+  <version>1001</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
   </dependencies>

--- a/src/plone/app/multilingual/profiles/default/types/LIF.xml
+++ b/src/plone/app/multilingual/profiles/default/types/LIF.xml
@@ -13,10 +13,10 @@
   <property name="allow_discussion">False</property>
   <property name="default_view">folder_listing</property>
   <property name="view_methods">
-    <element value="folder_summary_view"/>
-    <element value="folder_full_view"/>
-    <element value="folder_tabular_view"/>
-    <element value="atct_album_view"/>
+    <element value="summary_view"/>
+    <element value="full_view"/>
+    <element value="tabular_view"/>
+    <element value="album_view"/>
     <element value="folder_listing"/>
   </property>
   <property name="default_view_fallback">False</property>

--- a/src/plone/app/multilingual/profiles/default/types/LRF.xml
+++ b/src/plone/app/multilingual/profiles/default/types/LRF.xml
@@ -13,10 +13,10 @@
   <property name="allow_discussion">False</property>
   <property name="default_view">folder_listing</property>
   <property name="view_methods">
-    <element value="folder_summary_view"/>
-    <element value="folder_full_view"/>
-    <element value="folder_tabular_view"/>
-    <element value="atct_album_view"/>
+    <element value="summary_view"/>
+    <element value="full_view"/>
+    <element value="tabular_view"/>
+    <element value="album_view"/>
     <element value="folder_listing"/>
   </property>
   <property name="default_view_fallback">False</property>

--- a/src/plone/app/multilingual/upgrades.zcml
+++ b/src/plone/app/multilingual/upgrades.zcml
@@ -70,4 +70,11 @@
 
   </genericsetup:upgradeSteps>
 
+  <genericsetup:upgradeStep
+      source="1000"
+      destination="1001"
+      profile="plone.app.multilingual:default"
+      title="Update old layouts"
+      handler=".upgrades.update_old_layouts" />
+
 </configure>


### PR DESCRIPTION
For example, in Plone 6 `folder_summary_view` is no longer available: use `summary_view` instead.
In a project migrated from 5.1 to 5.2 to 6.0, several language root folders gave a 404 NotFound because they were using the `folder_summary_view`.