### PR TITLE
Move IEventBasic  language independent field setting to here.

### DIFF
--- a/news/414-paevent.breaking
+++ b/news/414-paevent.breaking
@@ -1,0 +1,3 @@
+Move language independent field declarations from plone.app.event to this package.
+This prepares this package to be used as a real core addon.
+[jensens]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 6.0.3.dev0
+version = 7.0.0.dev0
 name = plone.app.multilingual
 description = Multilingual Plone Content package
 long_description = file: README.rst, CREDITS.rst, CHANGES.rst

--- a/src/plone/app/multilingual/dx/__init__.py
+++ b/src/plone/app/multilingual/dx/__init__.py
@@ -1,0 +1,1 @@
+from . import languageindependent  # noqa: F401

--- a/src/plone/app/multilingual/dx/languageindependent.py
+++ b/src/plone/app/multilingual/dx/languageindependent.py
@@ -1,0 +1,9 @@
+from .interfaces import ILanguageIndependentField
+from plone.app.event.dx.behaviors import IEventBasic
+from zope.interface import alsoProvides
+
+# configure existing behaviors to be language independent
+alsoProvides(IEventBasic["start"], ILanguageIndependentField)
+alsoProvides(IEventBasic["end"], ILanguageIndependentField)
+alsoProvides(IEventBasic["whole_day"], ILanguageIndependentField)
+alsoProvides(IEventBasic["open_end"], ILanguageIndependentField)


### PR DESCRIPTION
This are plone.app.event IEventBasic fields.

Needs test/merge with plone/plone.app.event#367 from pam.

Prepares PAM to be moved abaove, between Plone and CMFPlone in thr architectural model.