### PR TITLE
Fix several problems with the Indonesian language [7.x]

### DIFF
--- a/news/304.bugfix.1
+++ b/news/304.bugfix.1
@@ -1,4 +1,5 @@
 Do not unset the language on the Indonesian root language folder when saving the control panel.
 This language has ``id`` as code.  This is not allowed as an id in Plone, so it is created as ``id-id`` instead.
 This needs some special handling.
+Added upgrade to recursively fix this language folder to set the Indonesian language.  This is only done when the folder itself has the wrong language.
 [maurits]

--- a/news/304.bugfix.1
+++ b/news/304.bugfix.1
@@ -1,0 +1,4 @@
+Do not unset the language on the Indonesian root language folder when saving the control panel.
+This language has ``id`` as code.  This is not allowed as an id in Plone, so it is created as ``id-id`` instead.
+This needs some special handling.
+[maurits]

--- a/news/304.bugfix.2
+++ b/news/304.bugfix.2
@@ -1,0 +1,2 @@
+Root language switcher: redirect to ``id-id`` if the Indonesian language is preferred.
+[maurits]

--- a/news/304.bugfix.3
+++ b/news/304.bugfix.3
@@ -1,0 +1,2 @@
+Fix ``set_recursive_language`` to actually find child objects.
+[maurits]

--- a/src/plone/app/multilingual/browser/setup.py
+++ b/src/plone/app/multilingual/browser/setup.py
@@ -118,6 +118,7 @@ class SetupMultilingualSite:
                 [
                     id_ not in _languagelist,
                     id_ not in _combinedlanguagelist,
+                    id_ != "id-id",
                     ITranslatable.providedBy(portal[id_]),
                 ]
             ):

--- a/src/plone/app/multilingual/browser/switcher.py
+++ b/src/plone/app/multilingual/browser/switcher.py
@@ -16,6 +16,10 @@ class LanguageSwitcher(BrowserView):
         plt = getToolByName(context, "portal_languages")
         pref = plt.getPreferredLanguage(self.request)
         default = plt.getDefaultLanguage()
+        # Handle Indonesian: its language code "id" is not allowed in Plone as
+        # content id, so its LRF is called "id-id".
+        pref = "id-id" if pref == "id" else pref
+        default = "id-id" if default == "id" else default
         ids = self.context.keys()
         target = (pref in ids) and pref or default
         url = f"{context.absolute_url()}/{target}"

--- a/src/plone/app/multilingual/profiles/default/metadata.xml
+++ b/src/plone/app/multilingual/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>1001</version>
+  <version>1002</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
   </dependencies>

--- a/src/plone/app/multilingual/subscriber.py
+++ b/src/plone/app/multilingual/subscriber.py
@@ -123,7 +123,7 @@ def set_recursive_language(ob, language):
         ITranslationManager(ob).update()
         reindex_object(ob)
 
-    for child in IFolderish.providedBy(ob) and ob.items() or ():
+    for child in IFolderish.providedBy(ob) and ob.values() or ():
         if ITranslatable.providedBy(child):
             set_recursive_language(child, language)
 

--- a/src/plone/app/multilingual/tests/test_setup.py
+++ b/src/plone/app/multilingual/tests/test_setup.py
@@ -5,6 +5,7 @@ from plone.app.multilingual.interfaces import ATTRIBUTE_NAME
 from plone.app.multilingual.interfaces import IPloneAppMultilingualInstalled
 from plone.app.multilingual.testing import PAM_INTEGRATION_PRESET_TESTING
 from plone.app.multilingual.testing import PAM_INTEGRATION_TESTING
+from plone.base.interfaces import ILanguage
 from Products.CMFCore.utils import getToolByName
 from zope.interface import alsoProvides
 
@@ -40,9 +41,12 @@ class TestSetupMultilingualSite(unittest.TestCase):
             self.assertNotIn(lang, portal_objects)
 
     def test_all_supported_languages(self):
-        """There was a language which code is 'id'.
+        """There is a language which code is 'id'.
+
+        This is Indonesian, or Bahasa Indonesia in that language.
         This broke the root language folder setup process.
         To get rid of that the folder is 'id-id'.
+        Here we test all languages, to be sure we catch such a corner case.
         """
         all_langs = AllContentLanguageVocabulary()(self.portal)
         for lang in all_langs:
@@ -57,10 +61,11 @@ class TestSetupMultilingualSite(unittest.TestCase):
         portal_objects = self.portal.objectIds()
 
         for lang in all_langs.by_value.keys():
-            if lang == "id":
-                self.assertIn("id-id", portal_objects)
-            else:
-                self.assertIn(lang, portal_objects)
+            # Special handling for Indonesian.
+            folder_id = "id-id" if lang == "id" else lang
+            self.assertIn(folder_id, portal_objects)
+            folder = self.portal[folder_id]
+            self.assertEqual(ILanguage(folder).get_language(), lang)
 
     def test_type_of_language_folders(self):
         """The created objects have to be 'Language Root Folder'."""
@@ -75,10 +80,10 @@ class TestSetupMultilingualSite(unittest.TestCase):
         setup_tool.setupSite(self.portal)
 
         for lang in all_langs.by_value.keys():
-            if lang == "id":
-                self.assertEqual(self.portal.get("id-id").portal_type, "LRF")
-            else:
-                self.assertEqual(self.portal.get(lang).portal_type, "LRF")
+            # Special handling for Indonesian.
+            folder_id = "id-id" if lang == "id" else lang
+            folder = self.portal[folder_id]
+            self.assertEqual(folder.portal_type, "LRF")
 
 
 class TestSetupMultilingualPresetSite(unittest.TestCase):

--- a/src/plone/app/multilingual/tests/test_switcher.py
+++ b/src/plone/app/multilingual/tests/test_switcher.py
@@ -1,0 +1,58 @@
+from plone.app.multilingual.browser.setup import SetupMultilingualSite
+from plone.app.multilingual.interfaces import IPloneAppMultilingualInstalled
+from plone.app.multilingual.testing import PAM_FUNCTIONAL_TESTING
+from plone.testing.z2 import Browser
+from Products.CMFCore.utils import getToolByName
+from zope.interface import alsoProvides
+
+import transaction
+import unittest
+
+
+class TestLanguageSwitcher(unittest.TestCase):
+    layer = PAM_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        # Set test variables
+        self.portal = self.layer["portal"]
+        self.language_tool = getToolByName(self.portal, "portal_languages")
+        self.portal_url = self.portal.absolute_url()
+        self.request = self.layer["request"]
+        alsoProvides(self.layer["request"], IPloneAppMultilingualInstalled)
+
+        # Add Indonesian as supported language, because this has corner cases:
+        # it's LRF cannot have id "id", so it is "id-id".
+        self.language_tool.addSupportedLanguage("id")
+        multilingual_setup_tool = SetupMultilingualSite()
+        multilingual_setup_tool.setupSite(self.portal)
+        transaction.commit()
+
+        # Setup testbrowser
+        self.browser = Browser(self.layer["app"])
+        self.browser.handleErrors = False
+
+    def test_switcher_redirects_to_default_english(self):
+        self.browser.open(self.portal_url)
+        self.assertEqual(self.browser.url, self.portal_url + "/en")
+
+    def test_switcher_redirects_to_default_indonesian(self):
+        self.language_tool.setDefaultLanguage("id")
+        transaction.commit()
+        self.browser.open(self.portal_url)
+        self.assertEqual(self.browser.url, self.portal_url + "/id-id")
+
+    def test_switcher_redirects_to_preferred_catalan(self):
+        # Tell Plone that we prefer Catalan.
+        self.browser.open(self.portal_url + "/ca?set_language=ca")
+        # Go to the site root.
+        self.browser.open(self.portal_url)
+        # We get redirected to our preferred language root folder.
+        self.assertEqual(self.browser.url, self.portal_url + "/ca")
+
+    def test_switcher_redirects_to_preferred_indonesian(self):
+        # Tell Plone that we prefer Indonesian.
+        self.browser.open(self.portal_url + "/id-id?set_language=id")
+        # Go to the site root.
+        self.browser.open(self.portal_url)
+        # We get redirected to our preferred language root folder.
+        self.assertEqual(self.browser.url, self.portal_url + "/id-id")

--- a/src/plone/app/multilingual/upgrades.py
+++ b/src/plone/app/multilingual/upgrades.py
@@ -1,4 +1,5 @@
 from plone.app.multilingual import logger
+from plone.app.multilingual.subscriber import set_recursive_language
 from plone.base.interfaces import ILanguage
 from plone.base.utils import unrestricted_construct_instance
 from plone.registry.interfaces import IRegistry
@@ -216,3 +217,24 @@ def update_old_layouts(context):
                 new_layout,
                 "/".join(obj.getPhysicalPath()),
             )
+
+
+def fix_indonesian_language(context):
+    """Fix the Indonesian language root folder, if it is there.
+
+    Indonesian needs special handling: its language code "id" is not allowed in
+    Plone as content id, so its LRF is called "id-id".
+    Not all parts of the code were always aware of this.
+    Result is that this LRF may have English (or nothing) as language.
+    """
+    utool = getToolByName(context, "portal_url")
+    portal = utool.getPortalObject()
+    if "id-id" not in portal.objectIds():
+        logger.info("Indonesian folder not available, so no need to fix.")
+        return
+    folder = portal["id-id"]
+    if ILanguage(folder).get_language() == "id":
+        logger.info("Indonesian folder 'id-id' already has language 'id'.")
+        return
+    logger.info("Recursively setting language of 'id-id' folder to Bahasa Indonesia.")
+    set_recursive_language(folder, "id")

--- a/src/plone/app/multilingual/upgrades.zcml
+++ b/src/plone/app/multilingual/upgrades.zcml
@@ -83,4 +83,12 @@
       handler=".upgrades.update_old_layouts"
       />
 
+  <genericsetup:upgradeStep
+      title="Fix Indonesian language"
+      profile="plone.app.multilingual:default"
+      source="1001"
+      destination="1002"
+      handler=".upgrades.fix_indonesian_language"
+      />
+
 </configure>


### PR DESCRIPTION
This language has ``id`` as code.  This is not allowed as an id in Plone, so it is created as ``id-id`` instead (since at least Plone 5.1, probably earlier as well).  This needs some special handling.

* Do not unset the language on the Indonesian root language folder when saving the control panel.  This fixes issue #304.
* Root language switcher: redirect to ``id-id`` if the Indonesian language is preferred.
* Added upgrade to recursively fix this language folder to set the Indonesian language.  This is only done when the folder itself has the wrong language.
* Fix ``set_recursive_language`` to actually find child objects.

This PR is for branch 7.x (Plone 6.0).  I want to port this to Plone 5.2 (branch 5.6.x) and Plone 6.1 (master branch) as well.  Maybe fix it on the 6.x branch as well, used until Plone 6.0.3.
But first let's have a review.