### PR TITLE
Fix setting Indonesian language cookie on site root. [6.x]

### DIFF
--- a/news/304.bugfix
+++ b/news/304.bugfix
@@ -1,0 +1,2 @@
+Fix setting Indonesian language cookie on site root: must be ``id``, not ``id-id``.
+[maurits]

--- a/src/plone/app/multilingual/browser/switcher.py
+++ b/src/plone/app/multilingual/browser/switcher.py
@@ -1,6 +1,8 @@
 from Acquisition import aq_inner
+from plone.i18n.interfaces import ILanguageUtility
 from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
+from zope.component import getUtility
 
 
 class LanguageSwitcher(BrowserView):
@@ -26,8 +28,10 @@ class LanguageSwitcher(BrowserView):
 
         # We need to set the language cookie on the first response or it will
         # be set on the frontpage itself, making it uncachable
-        langCookie = self.request.cookies.get("I18N_LANGUAGE")
-        if not langCookie or langCookie != target:
-            self.request.response.setCookie("I18N_LANGUAGE", target, path="/")
+        # In case of Indonesian, we need to use 'id', not 'id-id'.
+        target = "id" if target == "id-id" else target
+        tool = getUtility(ILanguageUtility)
+        # setLanguageCookie calls getLanguageCookie, and only sets a cookie when needed.
+        tool.setLanguageCookie(target, request=self.request)
 
         self.request.response.redirect(url, status=302)

--- a/src/plone/app/multilingual/tests/test_switcher.py
+++ b/src/plone/app/multilingual/tests/test_switcher.py
@@ -34,12 +34,14 @@ class TestLanguageSwitcher(unittest.TestCase):
     def test_switcher_redirects_to_default_english(self):
         self.browser.open(self.portal_url)
         self.assertEqual(self.browser.url, self.portal_url + "/en")
+        self.assertEqual(self.browser.cookies["I18N_LANGUAGE"], "en")
 
     def test_switcher_redirects_to_default_indonesian(self):
         self.language_tool.setDefaultLanguage("id")
         transaction.commit()
         self.browser.open(self.portal_url)
         self.assertEqual(self.browser.url, self.portal_url + "/id-id")
+        self.assertEqual(self.browser.cookies["I18N_LANGUAGE"], "id")
 
     def test_switcher_redirects_to_preferred_catalan(self):
         # Tell Plone that we prefer Catalan.
@@ -48,6 +50,7 @@ class TestLanguageSwitcher(unittest.TestCase):
         self.browser.open(self.portal_url)
         # We get redirected to our preferred language root folder.
         self.assertEqual(self.browser.url, self.portal_url + "/ca")
+        self.assertEqual(self.browser.cookies["I18N_LANGUAGE"], "ca")
 
     def test_switcher_redirects_to_preferred_indonesian(self):
         # Tell Plone that we prefer Indonesian.
@@ -56,3 +59,4 @@ class TestLanguageSwitcher(unittest.TestCase):
         self.browser.open(self.portal_url)
         # We get redirected to our preferred language root folder.
         self.assertEqual(self.browser.url, self.portal_url + "/id-id")
+        self.assertEqual(self.browser.cookies["I18N_LANGUAGE"], "id")


### PR DESCRIPTION
Must be id, not id-id.
See https://github.com/plone/plone.app.multilingual/issues/304

Also, use `ILanguageUtility.setLanguageCookie` instead of setting a cookie ourselves.