### PR TITLE
Don't screw up save and cancel button placement

### DIFF
--- a/news/435.bugfix
+++ b/news/435.bugfix
@@ -1,0 +1,1 @@
+Fixing placement of save and cancel buttons by not having javascript screw up their position

--- a/src/plone/app/multilingual/browser/javascript/babel_helper.js
+++ b/src/plone/app/multilingual/browser/javascript/babel_helper.js
@@ -216,5 +216,9 @@
             update_view();
         });
 
+        var intervalId = window.setInterval(function () {
+            update_view();
+        }, 1000);
+
     });
 }(jQuery));

--- a/src/plone/app/multilingual/browser/javascript/babel_helper.js
+++ b/src/plone/app/multilingual/browser/javascript/babel_helper.js
@@ -103,16 +103,6 @@
         });
     }
 
-    function sync_elements_vertically() {
-        // We do NOT calculate padding here again, because we might get
-        // to high padding because fields might have been shifted, increasing
-        // the padding.
-        var i = 0;
-        $.each(original_fields, function (i) {
-            sync_element_vertically($(original_fields[i]), $(destination_fields[i]), padding, i === 0);
-        });
-    }
-
     function update_view() {
         var order = 1,
             url_translate = $('input#url_translate').val(),
@@ -137,11 +127,11 @@
                 original_field.prepend("<div class='translator-widget' id='item_translation_" + order + "'></div>");
                 original_field.children('.translator-widget').click(function () {
                     var field = $(value).attr("rel");
-                        // Fetch source of text to translate.
+                    // Fetch source of text to translate.
                     var jsondata = {
-                            'field': field,
-                            'lang_source': langSource
-                        };
+                        'field': field,
+                        'lang_source': langSource
+                    };
                     var targetelement = destination_field.find('textarea');
                     var tiny_editor = destination_field.find("textarea.mce_editable");
                     if (!targetelement.length) {
@@ -226,6 +216,5 @@
             update_view();
         });
 
-        $(".formTabs, .pat-autotoc a").click(sync_elements_vertically);
     });
 }(jQuery));


### PR DESCRIPTION
Placement of save and cancel button was buggy, inhibiting the ability to use babel edit. The javascript is quite old and browsers seem to be capable of placing the elements right without fixes that were necessary 11 years ago. The outdated  code could be dropped since it doesn't work correctly any more.