### PR TITLE
Adds missing icon for Plone 6 Classic UI

### DIFF
--- a/src/plone/app/multilingual/browser/menu.py
+++ b/src/plone/app/multilingual/browser/menu.py
@@ -530,6 +530,7 @@ class TranslateSubMenuItem(BrowserSubMenuItem):
     )
     submenuId = "plone_contentmenu_multilingual"
     order = 5
+    icon = "translate"
 
     @property
     def action(self):


### PR DESCRIPTION
Adds missing bootstrap icon for translate menu in Plone 6 - Classic UI.

![image](https://github.com/plone/plone.app.multilingual/assets/13345340/4f5a0b1e-5b6b-49f4-8ebc-525985ce82d1)
