### PR TITLE
Configuring with plone/meta [7.x]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,6 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/config/default
+# See the inline comments on how to expand/tweak this configuration file
 #
 # EditorConfig Configuration file, for more details see:
 # http://EditorConfig.org
@@ -12,7 +13,8 @@
 root = true
 
 
-[*]  # For All Files
+[*]
+# Default settings for all files.
 # Unix-style newlines with a newline ending every file
 end_of_line = lf
 insert_final_newline = true
@@ -28,12 +30,27 @@ max_line_length = off
 # 4 space indentation
 indent_size = 4
 
-[*.{yml,zpt,pt,dtml,zcml}]
+[*.{yml,zpt,pt,dtml,zcml,html,xml}]
 # 2 space indentation
 indent_size = 2
+
+[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss}]
+# Frontend development
+# 2 space indentation
+indent_size = 2
+max_line_length = 80
 
 [{Makefile,.gitmodules}]
 # Tab indentation (no size specified, but view as 4 spaces)
 indent_style = tab
 indent_size = unset
 tab_width = unset
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [editorconfig]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,22 @@
+# Generated from:
+# https://github.com/plone/meta/tree/main/config/default
+# See the inline comments on how to expand/tweak this configuration file
+[flake8]
+doctests = 1
+ignore =
+    # black takes care of line length
+    E501,
+    # black takes care of where to break lines
+    W503,
+    # black takes care of spaces within slicing (list[:])
+    E203,
+    # black takes care of spaces after commas
+    E231,
+
+##
+# Add extra configuration options in .meta.toml:
+#  [flake8]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -1,0 +1,68 @@
+# Generated from:
+# https://github.com/plone/meta/tree/main/config/default
+# See the inline comments on how to expand/tweak this configuration file
+name: Meta
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+##
+# To set environment variables for all jobs, add in .meta.toml:
+# [github]
+# env = """
+#     debug: 1
+#     image-name: 'org/image'
+#     image-tag: 'latest'
+# """
+##
+
+jobs:
+  qa:
+    uses: plone/meta/.github/workflows/qa.yml@main
+  test:
+    uses: plone/meta/.github/workflows/test.yml@main
+  coverage:
+    uses: plone/meta/.github/workflows/coverage.yml@main
+  dependencies:
+    uses: plone/meta/.github/workflows/dependencies.yml@main
+  release_ready:
+    uses: plone/meta/.github/workflows/release_ready.yml@main
+  circular:
+    uses: plone/meta/.github/workflows/circular.yml@main
+
+##
+# To modify the list of default jobs being created add in .meta.toml:
+# [github]
+# jobs = [
+#    "qa",
+#    "test",
+#    "coverage",
+#    "dependencies",
+#    "release_ready",
+#    "circular",
+#    ]
+##
+
+##
+# To request that some OS level dependencies get installed
+# when running tests/coverage jobs, add in .meta.toml:
+# [github]
+# os_dependencies = "git libxml2 libxslt"
+##
+
+
+##
+# Specify additional jobs in .meta.toml:
+#  [github]
+#  extra_lines = """
+#  another:
+#    uses: org/repo/.github/workflows/file.yml@main
+#  """
+##

--- a/.gitignore
+++ b/.gitignore
@@ -1,46 +1,56 @@
-*.pyc
-*.egg
+# Generated from:
+# https://github.com/plone/meta/tree/main/config/default
+# See the inline comments on how to expand/tweak this configuration file
+# python related
 *.egg-info
+*.pyc
+*.pyo
+
+# translation related
 *.mo
 
-# Directories
-/eggs/*
-/parts/*
-/bin/*
-/extras/*
-/develop-eggs/*
-/var/*
-/build/*
-/dist/*
-/docs/_build
-/coverage
+# tools related
+build/
+.coverage
+.*project
+coverage.xml
+dist/
+docs/_build
+__pycache__/
+.tox
+.vscode/
+node_modules/
 
-# Sublime Text
-.codeintel/*
-MKcodeintel
-
-# buildout
+# venv / buildout related
+bin/
+develop-eggs/
+eggs/
+.eggs/
+etc/
 .installed.cfg
+include/
+lib/
+lib64
 .mr.developer.cfg
+parts/
+pyvenv.cfg
+var/
+local.cfg
 
-# eclipse
-.project
-.pydevproject
-.settings
+# mxdev
+/instance/
+/.make-sentinels/
+/*-mxdev.txt
+/reports/
+/sources/
+/venv/
+.installed.txt
 
-# Mac
-.DS_Store
 
-# Emacs
-.emacs.desktop*
-
-# Virtualenv
-/lib64/
-/lib/
-/include/
-/local/
-.Python
-
-# tests
-/test_acceptance/*
-robot_*
+##
+# Add extra configuration options in .meta.toml:
+#  [gitignore]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/.meta.toml
+++ b/.meta.toml
@@ -7,3 +7,4 @@ commit-id = "123ebc0a"
 
 [pyproject]
 codespell_ignores = "pres"
+dependencies_ignores = "['Products.CMFPlone', 'Products.LinguaPlone']"

--- a/.meta.toml
+++ b/.meta.toml
@@ -1,5 +1,9 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/config/default
+# See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "11f0db91"
+commit-id = "123ebc0a"
+
+[pyproject]
+codespell_ignores = "pres"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,37 +1,62 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/config/default
+# See the inline comments on how to expand/tweak this configuration file
 ci:
     autofix_prs: false
     autoupdate_schedule: monthly
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.2
+    rev: v3.15.0
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 24.1.1
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
-    rev: 3.0.4
+    rev: 3.1.0
     hooks:
     -   id: zpretty
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pre_commit]
+#  zpretty_extra_lines = """
+#  _your own configuration lines_
+#  """
+##
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
     -   id: flake8
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pre_commit]
+#  flake8_extra_lines = """
+#  _your own configuration lines_
+#  """
+##
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.2.6
     hooks:
     -   id: codespell
         additional_dependencies:
           - tomli
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pre_commit]
+#  codespell_extra_lines = """
+#  _your own configuration lines_
+#  """
+##
 -   repo: https://github.com/mgedmin/check-manifest
     rev: "0.49"
     hooks:
@@ -40,3 +65,30 @@ repos:
     rev: "4.2"
     hooks:
     -   id: pyroma
+-   repo: https://github.com/mgedmin/check-python-versions
+    rev: "0.22.0"
+    hooks:
+    -   id: check-python-versions
+        args: ['--only', 'setup.py,pyproject.toml']
+-   repo: https://github.com/collective/i18ndude
+    rev: "6.1.0"
+    hooks:
+    -   id: i18ndude
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pre_commit]
+#  i18ndude_extra_lines = """
+#  _your own configuration lines_
+#  """
+##
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pre_commit]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,11 @@
+# Generated from:
+# https://github.com/plone/meta/tree/main/config/default
+# See the inline comments on how to expand/tweak this configuration file
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/news/+meta.internal
+++ b/news/+meta.internal
@@ -1,0 +1,2 @@
+Update configuration files.
+[plone devs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ Zope = [
   'Products.CMFCore', 'Products.CMFDynamicViewFTI',
 ]
 python-dateutil = ['dateutil']
+ignore-packages = ['Products.CMFPlone', 'Products.LinguaPlone']
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,12 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/config/default
+# See the inline comments on how to expand/tweak this configuration file
+[build-system]
+requires = ["setuptools>=68.2"]
+
 [tool.towncrier]
-filename = "CHANGES.rst"
 directory = "news/"
+filename = "CHANGES.rst"
 title_format = "{version} ({project_date})"
 underlines = ["-", ""]
 
@@ -36,11 +40,45 @@ directory = "tests"
 name = "Tests"
 showcontent = true
 
+##
+# Add extra configuration options in .meta.toml:
+#  [pyproject]
+#  towncrier_extra_lines = """
+#  extra_configuration
+#  """
+##
+
 [tool.isort]
 profile = "plone"
 
+##
+# Add extra configuration options in .meta.toml:
+#  [pyproject]
+#  isort_extra_lines = """
+#  extra_configuration
+#  """
+##
+
 [tool.black]
 target-version = ["py38"]
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pyproject]
+#  black_extra_lines = """
+#  extra_configuration
+#  """
+##
+
+[tool.codespell]
+ignore-words-list = "discreet,pres"
+skip = "*.po,"
+##
+# Add extra configuration options in .meta.toml:
+#  [pyproject]
+#  codespell_ignores = "foo,bar"
+#  codespell_skip = "*.po,*.map,package-lock.json"
+##
 
 [tool.dependencychecker]
 Zope = [
@@ -48,19 +86,81 @@ Zope = [
   'App', 'OFS', 'Products.Five', 'Products.OFSP', 'Products.PageTemplates',
   'Products.SiteAccess', 'Shared', 'Testing', 'ZPublisher', 'ZTUtils',
   'Zope2', 'webdav', 'zmi',
+  # ExtensionClass own provided namespaces
+  'ExtensionClass', 'ComputedAttribute', 'MethodObject',
   # Zope dependencies
-  'Acquisition', 'DateTime', 'transaction', 'zExceptions', 'ZODB', 'zope.component',
-  'zope.configuration', 'zope.container', 'zope.deferredimport', 'zope.event',
-  'zope.exceptions', 'zope.globalrequest', 'zope.i18n', 'zope.i18nmessageid',
-  'zope.interface', 'zope.lifecycleevent', 'zope.location', 'zope.publisher',
-  'zope.schema', 'zope.security', 'zope.site', 'zope.traversing', 'AccessControl',
+  'AccessControl', 'Acquisition', 'AuthEncoding', 'beautifulsoup4', 'BTrees',
+  'cffi', 'Chameleon', 'DateTime', 'DocumentTemplate',
+  'MultiMapping', 'multipart', 'PasteDeploy', 'Persistence', 'persistent',
+  'pycparser', 'python-gettext', 'pytz', 'RestrictedPython', 'roman',
+  'soupsieve', 'transaction', 'waitress', 'WebOb', 'WebTest', 'WSGIProxy2',
+  'z3c.pt', 'zc.lockfile', 'ZConfig', 'zExceptions', 'ZODB', 'zodbpickle',
+  'zope.annotation', 'zope.browser', 'zope.browsermenu', 'zope.browserpage',
+  'zope.browserresource', 'zope.cachedescriptors', 'zope.component',
+  'zope.configuration', 'zope.container', 'zope.contentprovider',
+  'zope.contenttype', 'zope.datetime', 'zope.deferredimport',
+  'zope.deprecation', 'zope.dottedname', 'zope.event', 'zope.exceptions',
+  'zope.filerepresentation', 'zope.globalrequest', 'zope.hookable',
+  'zope.i18n', 'zope.i18nmessageid', 'zope.interface', 'zope.lifecycleevent',
+  'zope.location', 'zope.pagetemplate', 'zope.processlifetime', 'zope.proxy',
+  'zope.ptresource', 'zope.publisher', 'zope.schema', 'zope.security',
+  'zope.sequencesort', 'zope.site', 'zope.size', 'zope.structuredtext',
+  'zope.tal', 'zope.tales', 'zope.testbrowser', 'zope.testing',
+  'zope.traversing', 'zope.viewlet'
+]
+'Products.CMFCore' = [
+  'docutils', 'five.localsitemanager', 'Missing', 'Products.BTreeFolder2',
+  'Products.GenericSetup', 'Products.MailHost', 'Products.PythonScripts',
+  'Products.StandardCacheManagers', 'Products.ZCatalog', 'Record',
+  'zope.sendmail', 'Zope'
 ]
 'plone.base' = [
-  'AccessControl', 'Products.BTreeFolder2', 'Products.CMFCore',
-  'Products.CMFDynamicViewFTI', 'zope.deprecation',
+  'plone.batching', 'plone.registry', 'plone.schema','plone.z3cform',
+  'Products.CMFCore', 'Products.CMFDynamicViewFTI',
 ]
 python-dateutil = ['dateutil']
-ignore-packages = ['Products.LinguaPlone', 'Products.CMFPlone']
 
-[tool.codespell]
-ignore-words-list = "discreet,pres"
+##
+# Add extra configuration options in .meta.toml:
+#  [pyproject]
+#  dependencies_ignores = "['zestreleaser.towncrier']"
+#  dependencies_mappings = [
+#    "gitpython = ['git']",
+#    "pygithub = ['github']",
+#  ]
+##
+
+[tool.check-manifest]
+ignore = [
+    ".editorconfig",
+    ".flake8",
+    ".meta.toml",
+    ".pre-commit-config.yaml",
+    "dependabot.yml",
+    "mx.ini",
+    "tox.ini",
+
+]
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pyproject]
+#  check_manifest_ignores = """
+#      "*.map.js",
+#      "*.pyc",
+#  """
+#  check_manifest_extra_lines = """
+#  ignore-bad-ideas = [
+#      "some/test/file/PKG-INFO",
+#  ]
+#  """
+##
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pyproject]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,25 +27,3 @@ maintainer_email = releasemanager@plone.org
 
 [options]
 python_requires = >=3.8
-
-[check-manifest]
-ignore =
-    .editorconfig
-    .meta.toml
-    .pre-commit-config.yaml
-    tox.ini
-
-[bdist_wheel]
-universal = 0
-
-[flake8]
-doctests = 1
-ignore =
-    # black takes care of line length
-    E501,
-    # black takes care of where to break lines
-    W503,
-    # black takes care of spaces within slicing (list[:])
-    E203,
-    # black takes care of spaces after commas
-    E231,

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "Products.CMFCore",
         "Products.GenericSetup",
         "Products.statusmessages",
+        "Zope",
         "plone.app.content",
         "plone.app.contentmenu",
         "plone.app.dexterity",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """Setup plone.app.multilingual."""
+
 from setuptools import find_packages
 from setuptools import setup
 

--- a/src/plone/app/multilingual/browser/controlpanel.py
+++ b/src/plone/app/multilingual/browser/controlpanel.py
@@ -6,7 +6,6 @@ from plone.app.registry.browser import controlpanel
 from plone.app.uuid.utils import uuidToObject
 from plone.base.interfaces import ILanguage
 from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.controlpanel.browser.language import LanguageControlPanelForm
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
@@ -18,6 +17,13 @@ from zope.interface.interfaces import ComponentLookupError
 from zope.schema.interfaces import IVocabularyFactory
 
 import json
+
+
+try:
+    # In Plone 6.0 we try not to depend on Products.CMFPlone.
+    from Products.CMFPlone.controlpanel.browser.language import LanguageControlPanelForm
+except ImportError:
+    LanguageControlPanelForm = controlpanel.RegistryEditForm
 
 
 _ = MessageFactory("plone.app.multilingual")

--- a/src/plone/app/multilingual/browser/menu.py
+++ b/src/plone/app/multilingual/browser/menu.py
@@ -530,7 +530,6 @@ class TranslateSubMenuItem(BrowserSubMenuItem):
     )
     submenuId = "plone_contentmenu_multilingual"
     order = 5
-    extra = {"id": "plone-contentmenu-multilingual"}
 
     @property
     def action(self):

--- a/src/plone/app/multilingual/browser/templates/modify_translations.pt
+++ b/src/plone/app/multilingual/browser/templates/modify_translations.pt
@@ -74,7 +74,7 @@
                      href="#"
                      title="Disconnect translation"
                      tal:attributes="
-                       href string:${context/absolute_url}/disconnect_translation?came_from=${context/UID}&language=${lang};;
+                       href string:${context/absolute_url}/disconnect_translation?came_from=${context/UID}&language=${lang};
                      "
                      i18n:attributes="title disconnect_translation"
                   >

--- a/src/plone/app/multilingual/manager.py
+++ b/src/plone/app/multilingual/manager.py
@@ -74,7 +74,7 @@ class TranslationManager:
         if not language and language != "":
             raise KeyError("There is no target language")
 
-        if type(content) == str:
+        if isinstance(content, str):
             content = uuidToObject(content)
 
         # Check if exists and is not myself

--- a/src/plone/app/multilingual/tests/test_form.py
+++ b/src/plone/app/multilingual/tests/test_form.py
@@ -47,9 +47,9 @@ class TestForm(unittest.TestCase):
         self.browser.open(a_ca.absolute_url() + "/@@create_translation?language=en")
 
         # Fill in translation details
-        self.browser.getControl(
-            name="form.widgets.IDublinCore.title"
-        ).value = "Test document"
+        self.browser.getControl(name="form.widgets.IDublinCore.title").value = (
+            "Test document"
+        )
         self.browser.getControl(name="form.buttons.save").click()
 
         self.portal._p_jar.sync()
@@ -75,9 +75,9 @@ class TestForm(unittest.TestCase):
         add_translation_url = self.browser.url
 
         # Fill in translation details
-        self.browser.getControl(
-            name="form.widgets.IDublinCore.title"
-        ).value = "Test document"
+        self.browser.getControl(name="form.widgets.IDublinCore.title").value = (
+            "Test document"
+        )
         self.browser.getControl(name="form.buttons.save").click()
 
         self.portal._p_jar.sync()
@@ -101,9 +101,9 @@ class TestForm(unittest.TestCase):
         self.browser.open(a_ca.absolute_url() + "/@@create_translation?language=en")
 
         # Fill in translation details
-        self.browser.getControl(
-            name="form.widgets.IDublinCore.title"
-        ).value = "Test document"
+        self.browser.getControl(name="form.widgets.IDublinCore.title").value = (
+            "Test document"
+        )
         self.browser.getControl(name="form.buttons.save").click()
 
         # Unregister translation
@@ -185,9 +185,9 @@ class TestForm(unittest.TestCase):
         self.browser.open(a_ca.absolute_url() + "/@@create_translation?language=en")
 
         # Fill in translation details
-        self.browser.getControl(
-            name="form.widgets.IDublinCore.title"
-        ).value = "Test document"
+        self.browser.getControl(name="form.widgets.IDublinCore.title").value = (
+            "Test document"
+        )
         self.browser.getControl(name="form.buttons.save").click()
 
         # Remove translation
@@ -210,9 +210,9 @@ class TestForm(unittest.TestCase):
             + "/ca/test-folder/@@create_translation?language=en"
         )
 
-        self.browser.getControl(
-            name="form.widgets.IDublinCore.title"
-        ).value = "Test folder"
+        self.browser.getControl(name="form.widgets.IDublinCore.title").value = (
+            "Test folder"
+        )
         self.browser.getControl(name="form.buttons.save").click()
 
         self.portal._p_jar.sync()
@@ -234,9 +234,9 @@ class TestForm(unittest.TestCase):
             af_ca.absolute_url() + "/" + b_ca.id + "/@@create_translation?language=en"
         )
 
-        self.browser.getControl(
-            name="form.widgets.IDublinCore.title"
-        ).value = "Test folder"
+        self.browser.getControl(name="form.widgets.IDublinCore.title").value = (
+            "Test folder"
+        )
         self.browser.getControl(name="form.buttons.save").click()
 
         self.portal._p_jar.sync()

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,51 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/config/default
+# See the inline comments on how to expand/tweak this configuration file
 [tox]
 # We need 4.4.0 for constrain_package_deps.
 min_version = 4.4.0
 envlist =
-    format
     lint
     test
+    dependencies
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [tox]
+#  envlist_lines = """
+#      my_other_environment
+#  """
+#  config_lines = """
+#  my_extra_top_level_tox_configuration_lines
+#  """
+##
 
 [testenv]
+skip_install = true
 allowlist_externals =
-    sh
+    echo
+    false
+# Make sure typos like `tox -e formaat` are caught instead of silently doing nothing.
+# See https://github.com/tox-dev/tox/issues/2858.
+commands =
+    echo "Unrecognized environment name {envname}"
+    false
+
+##
+# Add extra configuration options in .meta.toml:
+#  [tox]
+#  testenv_options = """
+#  basepython = /usr/bin/python3.8
+#  """
+##
+
+[testenv:init]
+description = Prepare environment
+skip_install = true
+commands =
+    echo "Initial setup complete"
+
 
 [testenv:format]
 description = automatically reformat code
@@ -32,37 +67,153 @@ commands =
     pre-commit run -a
 
 [testenv:dependencies]
-description = check if the package defines all its dependencies and generate a graph out of them
+description = check if the package defines all its dependencies
+skip_install = true
 deps =
-    z3c.dependencychecker==2.11
+    build
+    z3c.dependencychecker==2.14.3
+commands =
+    python -m build --sdist
+    dependencychecker
+
+[testenv:dependencies-graph]
+description = generate a graph out of the dependencies of the package
+skip_install = false
+allowlist_externals =
+    sh
+deps =
     pipdeptree==2.5.1
     graphviz  # optional dependency of pipdeptree
 commands =
-    dependencychecker
-    sh -c 'pipdeptree --exclude setuptools,wheel,pipdeptree,z3c.dependencychecker,zope.interface,zope.component --graph-output svg > dependencies.svg'
+    sh -c 'pipdeptree --exclude setuptools,wheel,pipdeptree,zope.interface,zope.component --graph-output svg > dependencies.svg'
 
 [testenv:test]
-usedevelop = true
+description = run the distribution tests
+use_develop = true
+skip_install = false
 constrain_package_deps = true
-set_env = ROBOT_BROWSER=headlesschrome
+set_env =
+    ROBOT_BROWSER=headlesschrome
+
+##
+# Specify extra test environment variables in .meta.toml:
+#  [tox]
+#  test_environment_variables = """
+#      PIP_EXTRA_INDEX_URL=https://my-pypi.my-server.com/
+#  """
+#
+# Set constrain_package_deps .meta.toml:
+#  [tox]
+#  constrain_package_deps = "false"
+##
 deps =
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
+
+##
+# Specify additional deps in .meta.toml:
+#  [tox]
+#  test_deps_additional = "-esources/plonegovbr.portal_base[test]"
+#
+# Specify a custom constraints file in .meta.toml:
+#  [tox]
+#  constraints_file = "https://my-server.com/constraints.txt"
+##
 commands =
+    rfbrowser init
     zope-testrunner --all --test-path={toxinidir}/src -s plone.app.multilingual {posargs}
 extras =
     test
 
+##
+# Add extra configuration options in .meta.toml:
+#  [tox]
+#  test_extras = """
+#      tests
+#      widgets
+#  """
+##
+
 [testenv:coverage]
-usedevelop = true
+description = get a test coverage report
+use_develop = true
+skip_install = false
 constrain_package_deps = true
-set_env = ROBOT_BROWSER=headlesschrome
+set_env =
+    ROBOT_BROWSER=headlesschrome
+
+##
+# Specify extra test environment variables in .meta.toml:
+#  [tox]
+#  test_environment_variables = """
+#      PIP_EXTRA_INDEX_URL=https://my-pypi.my-server.com/
+#  """
+##
 deps =
     coverage
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
+
 commands =
-    coverage run {envbindir}/zope-testrunner --all --test-path={toxinidir}/src -s plone.app.multilingual {posargs}
+    rfbrowser init
+    coverage run --branch --source plone.app.multilingual {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir}/src -s plone.app.multilingual {posargs}
     coverage report -m --format markdown
+    coverage xml
+    coverage html
 extras =
     test
+
+
+[testenv:release-check]
+description = ensure that the distribution is ready to release
+skip_install = true
+deps =
+    twine
+    build
+    towncrier
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+
+commands =
+    # fake version to not have to install the package
+    # we build the change log as news entries might break
+    # the README that is displayed on PyPI
+    towncrier build --version=100.0.0 --yes
+    python -m build --sdist
+    twine check dist/*
+
+[testenv:circular]
+description = ensure there are no cyclic dependencies
+use_develop = true
+skip_install = false
+set_env =
+
+##
+# Specify extra test environment variables in .meta.toml:
+#  [tox]
+#  test_environment_variables = """
+#      PIP_EXTRA_INDEX_URL=https://my-pypi.my-server.com/
+#  """
+##
+allowlist_externals =
+    sh
+deps =
+    pipdeptree
+    pipforester
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+
+commands =
+    # Generate the full dependency tree
+    sh -c 'pipdeptree -j > forest.json'
+    # Generate a DOT graph with the circular dependencies, if any
+    pipforester -i forest.json -o forest.dot --cycles
+    # Report if there are any circular dependencies, i.e. error if there are any
+    pipforester -i forest.json --check-cycles -o /dev/null
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [tox]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##


### PR DESCRIPTION
This updates the 7.x branch to latest plone/meta.

Mostly I wondered if the circular import check would fail here, which is not the case.

Wait, the `dependencies` check *does* fail.  Let me check that.  Okay, fixed in second commit.