### PR TITLE
Set tox use_mxdev = true. Depend on Zope to fix dependency check.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,8 @@
 root = true
 
 
-[*]  # For All Files
+[*]
+# Default settings for all files.
 # Unix-style newlines with a newline ending every file
 end_of_line = lf
 insert_final_newline = true
@@ -29,11 +30,12 @@ max_line_length = off
 # 4 space indentation
 indent_size = 4
 
-[*.{yml,zpt,pt,dtml,zcml}]
+[*.{yml,zpt,pt,dtml,zcml,html,xml}]
 # 2 space indentation
 indent_size = 2
 
-[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss,html}]  # Frontend development
+[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss}]
+# Frontend development
 # 2 space indentation
 indent_size = 2
 max_line_length = 80

--- a/.meta.toml
+++ b/.meta.toml
@@ -20,3 +20,4 @@ dependencies_ignores = "['Products.LinguaPlone']"
 
 [tox]
 use_mxdev = true
+constrain_package_deps = "true"

--- a/.meta.toml
+++ b/.meta.toml
@@ -3,7 +3,7 @@
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "6a477508"
+commit-id = "a950ca82"
 
 [gitignore]
 extra_lines = """
@@ -17,3 +17,6 @@ check_manifest_ignores = """
 """
 codespell_ignores = "pres"
 dependencies_ignores = "['Products.LinguaPlone']"
+
+[tox]
+use_mxdev = true

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,11 @@
+# Generated from:
+# https://github.com/plone/meta/tree/main/config/default
+# See the inline comments on how to expand/tweak this configuration file
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/news/+meta.internal
+++ b/news/+meta.internal
@@ -1,0 +1,2 @@
+Update configuration files.
+[plone devs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,20 +134,27 @@ ignore-packages = ['Products.LinguaPlone']
 [tool.check-manifest]
 ignore = [
     ".editorconfig",
+    ".flake8",
     ".meta.toml",
     ".pre-commit-config.yaml",
-    "tox.ini",
-    ".flake8",
+    "dependabot.yml",
     "mx.ini",
     "requirements.txt",
+    "tox.ini",
 
 ]
+
 ##
 # Add extra configuration options in .meta.toml:
 #  [pyproject]
 #  check_manifest_ignores = """
 #      "*.map.js",
 #      "*.pyc",
+#  """
+#  check_manifest_extra_lines = """
+#  ignore-bad-ideas = [
+#      "some/test/file/PKG-INFO",
+#  ]
 #  """
 ##
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "Products.CMFPlone",
         "Products.GenericSetup",
         "Products.statusmessages",
+        "Zope",
         "plone.app.content",
         "plone.app.contentmenu",
         "plone.app.dexterity",

--- a/tox.ini
+++ b/tox.ini
@@ -43,8 +43,11 @@ commands =
 [testenv:init]
 description = Prepare environment
 skip_install = true
+deps =
+    mxdev
 commands =
-    echo "Initial setup complete"
+    mxdev -c mx.ini
+    echo "Initial setup for mxdev"
 
 
 [testenv:format]
@@ -71,7 +74,7 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
-    z3c.dependencychecker==2.11
+    z3c.dependencychecker==2.14.3
 commands =
     python -m build --sdist
     dependencychecker
@@ -89,6 +92,9 @@ commands =
 
 [testenv:test]
 description = run the distribution tests
+use_develop = true
+skip_install = false
+constrain_package_deps = false
 set_env =
     ROBOT_BROWSER=headlesschrome
 
@@ -104,9 +110,8 @@ set_env =
 #  constrain_package_deps = "false"
 ##
 deps =
-    mxdev
     zope.testrunner
-    -c https://dist.plone.org/release/6.1-dev/constraints.txt
+    -c constraints-mxdev.txt
 
 ##
 # Specify additional deps in .meta.toml:
@@ -117,9 +122,6 @@ deps =
 #  [tox]
 #  constraints_file = "https://my-server.com/constraints.txt"
 ##
-commands_pre =
-    mxdev -c mx.ini
-    pip install -rrequirements-mxdev.txt
 commands =
     rfbrowser init
     zope-testrunner --all --test-path={toxinidir}/src -s plone.app.multilingual {posargs}
@@ -137,6 +139,9 @@ extras =
 
 [testenv:coverage]
 description = get a test coverage report
+use_develop = true
+skip_install = false
+constrain_package_deps = false
 set_env =
     ROBOT_BROWSER=headlesschrome
 
@@ -149,18 +154,15 @@ set_env =
 ##
 deps =
     coverage
-    mxdev
     zope.testrunner
-    -c https://dist.plone.org/release/6.1-dev/constraints.txt
+    -c constraints-mxdev.txt
 
-commands_pre =
-    mxdev -c mx.ini
-    pip install -rrequirements-mxdev.txt
 commands =
     rfbrowser init
     coverage run --branch --source plone.app.multilingual {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir}/src -s plone.app.multilingual {posargs}
     coverage report -m --format markdown
     coverage xml
+    coverage html
 extras =
     test
 
@@ -172,7 +174,7 @@ deps =
     twine
     build
     towncrier
-    -c https://dist.plone.org/release/6.1-dev/constraints.txt
+    -c constraints-mxdev.txt
 
 commands =
     # fake version to not have to install the package
@@ -184,6 +186,11 @@ commands =
 
 [testenv:circular]
 description = ensure there are no cyclic dependencies
+use_develop = true
+skip_install = false
+# Here we must always constrain the package deps to what is already installed,
+# otherwise we simply get the latest from PyPI, which may not work.
+constrain_package_deps = true
 set_env =
 
 ##
@@ -196,14 +203,10 @@ set_env =
 allowlist_externals =
     sh
 deps =
-    mxdev
     pipdeptree
     pipforester
-    -c https://dist.plone.org/release/6.1-dev/constraints.txt
+    -c constraints-mxdev.txt
 
-commands_pre =
-    mxdev -c mx.ini
-    pip install -rrequirements-mxdev.txt
 commands =
     # Generate the full dependency tree
     sh -c 'pipdeptree -j > forest.json'

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,7 @@ commands =
 description = run the distribution tests
 use_develop = true
 skip_install = false
-constrain_package_deps = false
+constrain_package_deps = true
 set_env =
     ROBOT_BROWSER=headlesschrome
 
@@ -141,7 +141,7 @@ extras =
 description = get a test coverage report
 use_develop = true
 skip_install = false
-constrain_package_deps = false
+constrain_package_deps = true
 set_env =
     ROBOT_BROWSER=headlesschrome
 


### PR DESCRIPTION
Configuring with plone/meta.

Note that in `requirements.txt` we still tell tox/mxdev to use Plone 6.1.