### PR TITLE
get the object to be translated correctly in Google Translate view

### DIFF
--- a/news/303.bugfix
+++ b/news/303.bugfix
@@ -1,0 +1,2 @@
+Get the object to be translated correctly
+[erral]

--- a/src/plone/app/multilingual/browser/javascript/babel_helper.js
+++ b/src/plone/app/multilingual/browser/javascript/babel_helper.js
@@ -128,10 +128,16 @@
                 original_field.children('.translator-widget').click(function () {
                     var field = $(value).attr("rel");
                     // Fetch source of text to translate.
+
+                    // we use the current URL to get the context's UID
+                    var url_parts = document.location.pathname.split('++addtranslation++')
+
                     var jsondata = {
                         'field': field,
-                        'lang_source': langSource
-                    };
+                        'lang_source': langSource,
+                        // we use the second part of the url_parts, the uid itself
+                        'context_uid': url_parts[1]
+                      };
                     var targetelement = destination_field.find('textarea');
                     var tiny_editor = destination_field.find("textarea.mce_editable");
                     if (!targetelement.length) {

--- a/src/plone/app/multilingual/browser/translate.py
+++ b/src/plone/app/multilingual/browser/translate.py
@@ -58,7 +58,7 @@ class gtranslation_service_dexterity(BrowserView):
         ):
             return _("Need a field")
         else:
-            context_uid = self.request.form.get('context_uid', None)
+            context_uid = self.request.form.get("context_uid", None)
             if context_uid is None:
                 # try with context if no translation uid is present
                 manager = ITranslationManager(self.context)

--- a/src/plone/app/multilingual/browser/translate.py
+++ b/src/plone/app/multilingual/browser/translate.py
@@ -2,10 +2,10 @@ from Acquisition import aq_inner
 from plone.app.multilingual import _
 from plone.app.multilingual.interfaces import IMultiLanguageExtraOptionsSchema
 from plone.app.multilingual.interfaces import ITranslationManager
+from plone.app.uuid.utils import uuidToObject
 from plone.base.interfaces import ILanguage
 from plone.registry.interfaces import IRegistry
 from plone.uuid.interfaces import IUUID
-from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
 from zope.component import getUtility
 
@@ -63,10 +63,8 @@ class gtranslation_service_dexterity(BrowserView):
                 # try with context if no translation uid is present
                 manager = ITranslationManager(self.context)
             else:
-                catalog = getToolByName(self.context, "portal_catalog")
-                brains = catalog(UID=context_uid)
-                if len(brains):
-                    context = brains[0].getObject()
+                context = uuidToObject(context_uid)
+                if context is not None:
                     manager = ITranslationManager(context)
                 else:
                     manager = ITranslationManager(self.context)

--- a/src/plone/app/multilingual/browser/translate.py
+++ b/src/plone/app/multilingual/browser/translate.py
@@ -5,6 +5,7 @@ from plone.app.multilingual.interfaces import ITranslationManager
 from plone.base.interfaces import ILanguage
 from plone.registry.interfaces import IRegistry
 from plone.uuid.interfaces import IUUID
+from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
 from zope.component import getUtility
 
@@ -57,7 +58,19 @@ class gtranslation_service_dexterity(BrowserView):
         ):
             return _("Need a field")
         else:
-            manager = ITranslationManager(self.context)
+            context_uid = self.request.form.get('context_uid', None)
+            if context_uid is None:
+                # try with context if no translation uid is present
+                manager = ITranslationManager(self.context)
+            else:
+                catalog = getToolByName(self.context, "portal_catalog")
+                brains = catalog(UID=context_uid)
+                if len(brains):
+                    context = brains[0].getObject()
+                    manager = ITranslationManager(context)
+                else:
+                    manager = ITranslationManager(self.context)
+
             registry = getUtility(IRegistry)
             settings = registry.forInterface(
                 IMultiLanguageExtraOptionsSchema, prefix="plone"


### PR DESCRIPTION
Fixes #303 

It looks like previously the view was executed in the context to be translated, which is not true any more. Now this view is executed in a view traverser like `/es/++addtranslation++2490009c505b4d4b9a030ca631a70a5f` the context (which would be `es` in this case) is usually the parent folder and not the object to be translated. 

The UID in the view traverser (`2490009c505b4d4b9a030ca631a70a5f`) signals the UID of the object to be translated, so we get it via JavaScript and send it to the translation view, which gets the object correctly.