### PR TITLE
Improve TranslationManager

### DIFF
--- a/news/495.bugfix
+++ b/news/495.bugfix
@@ -1,0 +1,2 @@
+The methods `get_translation(s)` are safely callable for anonymous access. The method `add_translation` returns now the created translation. [pgrunewald]
+

--- a/src/plone/app/multilingual/manager.py
+++ b/src/plone/app/multilingual/manager.py
@@ -140,6 +140,7 @@ class TranslationManager:
         self.register_translation(language, translated_object)
         # event
         notify(ObjectTranslatedEvent(self.context, translated_object, language))
+        return translated_object
 
     def add_translation_delegated(self, language):
         """
@@ -169,7 +170,7 @@ class TranslationManager:
         )
         if len(brains) != 1:
             return None
-        return brains[0].getObject()
+        return brains[0]._unrestrictedGetObject()
 
     def get_restricted_translation(self, language):
         """see interfaces"""
@@ -187,7 +188,7 @@ class TranslationManager:
             TranslationGroup=self.tg,
         )
         for brain in brains:
-            translations[brain.Language] = brain.getObject()
+            translations[brain.Language] = brain._unrestrictedGetObject()
         return translations
 
     def get_restricted_translations(self):

--- a/src/plone/app/multilingual/tests/test_api.py
+++ b/src/plone/app/multilingual/tests/test_api.py
@@ -96,9 +96,19 @@ class TestBasicAPI(unittest.TestCase):
         translations = ITranslationManager(self.a_ca).get_translations()
         self.assertEqual(translations, {"ca": self.a_ca})
 
+    def test_get_translations_for_anonymous(self):
+        logout()
+        # get_translations() works also for anonymous
+        self.test_get_translations()
+
     def test_get_translation(self):
         a_ca = ITranslationManager(self.a_ca).get_translation("ca")
         self.assertEqual(a_ca, self.a_ca)
+
+    def test_get_translation_for_anonymous(self):
+        logout()
+        # also anonymous should be able to use get_translation()
+        self.test_get_translation()
 
     def test_get_translated_languages(self):
         translated_languages = ITranslationManager(self.a_ca).get_translated_languages()
@@ -127,10 +137,13 @@ class TestBasicAPI(unittest.TestCase):
         self.assertNotIn("test-document", self.portal["es"].objectIds())
 
         # Create es translation
-        ITranslationManager(self.a_ca).add_translation("es")
+        a_es = ITranslationManager(self.a_ca).add_translation("es")
 
         # Check if it exists
         self.assertIn("test-document", self.portal["es"].objectIds())
+
+        # Check if this is the returned translation object
+        self.assertEqual(a_es, self.portal["es"]["test-document"])
 
         # Check language
         language = ILanguage(self.portal["es"]["test-document"]).get_language()
@@ -176,8 +189,11 @@ class TestLanguageRootFolderAPI(unittest.TestCase):
         )
 
         # Translate
-        ITranslationManager(a_ca).add_translation("es")
-        a_es = ITranslationManager(a_ca).get_translation("es")
+        a_es = ITranslationManager(a_ca).add_translation("es")
+
+        # Check that add_translation("es") and get_translation("es") return the
+        # identical object
+        self.assertEqual(a_es, ITranslationManager(a_ca).get_translation("es"))
 
         # Check that translation is registered
         self.assertEqual(


### PR DESCRIPTION
The methods `get_translation(s)` safely callable for anonymous access. The method `add_translation` returns now the created translation.

Fixes #495 