### PR TITLE
Consider context None or without REQUEST in make_relation_root_path

### DIFF
--- a/news/498.bugfix
+++ b/news/498.bugfix
@@ -1,1 +1,1 @@
-[yurj] It can happen that widgets used in the control panel have context as None or that context.REQUEST is missing. This function is used as basepath for widget queries.
+Fix the default path for the relation widget if the current context or request are unknown. [yurj]

--- a/news/498.bugfix
+++ b/news/498.bugfix
@@ -1,1 +1,1 @@
-[yurj] In control panels, it can happen that context can be None or context.REQUEST is missing and this function is usedas basepath for widget queries.
+[yurj] It can happen that widgets used in the control panel have context as None or that context.REQUEST is missing. This function is used as basepath for widget queries.

--- a/news/498.bugfix
+++ b/news/498.bugfix
@@ -1,0 +1,1 @@
+[yurj] In control panels, it can happen that context can be None or context.REQUEST is missing and this function is usedas basepath for widget queries.

--- a/src/plone/app/multilingual/browser/interfaces.py
+++ b/src/plone/app/multilingual/browser/interfaces.py
@@ -3,7 +3,6 @@ from plone.app.multilingual import _
 from plone.app.multilingual.browser.vocabularies import untranslated_languages
 from plone.app.multilingual.interfaces import ITranslationManager
 from plone.app.z3cform.widgets.contentbrowser import ContentBrowserFieldWidget
-from plone import api
 from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.base.interfaces import IPloneSiteRoot

--- a/src/plone/app/multilingual/browser/interfaces.py
+++ b/src/plone/app/multilingual/browser/interfaces.py
@@ -28,7 +28,7 @@ def make_relation_root_path(context):
 
     # Try to find the "closest" object in the target language
     current_object = context
-    request = context.REQUEST if hasattr(context, 'REQUEST') else getRequest()
+    request = context.REQUEST if hasattr(context, "REQUEST") else getRequest()
     target_language = request.get("language", None)
 
     if target_language is None:

--- a/src/plone/app/multilingual/browser/interfaces.py
+++ b/src/plone/app/multilingual/browser/interfaces.py
@@ -3,6 +3,7 @@ from plone.app.multilingual import _
 from plone.app.multilingual.browser.vocabularies import untranslated_languages
 from plone.app.multilingual.interfaces import ITranslationManager
 from plone.app.z3cform.widgets.contentbrowser import ContentBrowserFieldWidget
+from plone import api
 from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.base.interfaces import IPloneSiteRoot
@@ -28,8 +29,8 @@ def make_relation_root_path(context):
 
     # Try to find the "closest" object in the target language
     current_object = context
-    request = context.REQUEST if hasattr(context, "REQUEST") else getRequest()
-    target_language = request.get("language", None)
+    request = getRequest()
+    target_language = request.get("LANGUAGE", None)
 
     if target_language is None:
         return "/".join(site.getPhysicalPath())

--- a/src/plone/app/multilingual/browser/interfaces.py
+++ b/src/plone/app/multilingual/browser/interfaces.py
@@ -22,14 +22,18 @@ def make_relation_root_path(context):
     security_manager = getSecurityManager()
     site = getSite()
 
+    # Use the old behavior if context is None or REQUEST is missing, otherwise
+    # the code below will fail because REQUEST or aq_parent are missing
+    if context is None or not getattr(context, "REQUEST"):
+        return "/".join(site.getPhysicalPath())
+
     # This should not happen, there's no View permission for the current object
     if not security_manager.checkPermission("View", context):
         return "/".join(site.getPhysicalPath())
 
     # Try to find the "closest" object in the target language
     current_object = context
-    request = getRequest()
-    target_language = request.get("LANGUAGE", None)
+    target_language = context.REQUEST.get("language", None)
 
     if target_language is None:
         return "/".join(site.getPhysicalPath())

--- a/src/plone/app/multilingual/browser/interfaces.py
+++ b/src/plone/app/multilingual/browser/interfaces.py
@@ -13,6 +13,7 @@ from zope import schema
 from zope.browsermenu.interfaces import IBrowserMenu
 from zope.browsermenu.interfaces import IBrowserSubMenuItem
 from zope.component.hooks import getSite
+from zope.globalrequest import getRequest
 from zope.interface import provider
 from zope.schema.interfaces import IContextAwareDefaultFactory
 

--- a/src/plone/app/multilingual/browser/interfaces.py
+++ b/src/plone/app/multilingual/browser/interfaces.py
@@ -27,7 +27,8 @@ def make_relation_root_path(context):
 
     # Try to find the "closest" object in the target language
     current_object = context
-    target_language = context.REQUEST.get("language", None)
+    request = context.REQUEST if hasattr(context, 'REQUEST') else getRequest()
+    target_language = request.get("language", None)
 
     if target_language is None:
         return "/".join(site.getPhysicalPath())

--- a/src/plone/app/multilingual/browser/interfaces.py
+++ b/src/plone/app/multilingual/browser/interfaces.py
@@ -13,7 +13,6 @@ from zope import schema
 from zope.browsermenu.interfaces import IBrowserMenu
 from zope.browsermenu.interfaces import IBrowserSubMenuItem
 from zope.component.hooks import getSite
-from zope.globalrequest import getRequest
 from zope.interface import provider
 from zope.schema.interfaces import IContextAwareDefaultFactory
 

--- a/src/plone/app/multilingual/browser/interfaces.py
+++ b/src/plone/app/multilingual/browser/interfaces.py
@@ -23,7 +23,7 @@ def make_relation_root_path(context):
 
     # Use the old behavior if context is None or REQUEST is missing, otherwise
     # the code below will fail because REQUEST or aq_parent are missing
-    if context is None or not getattr(context, "REQUEST"):
+    if context is None or not getattr(context, "REQUEST", None):
         return "/".join(site.getPhysicalPath())
 
     # This should not happen, there's no View permission for the current object


### PR DESCRIPTION
Closes #498

In control panels, it can happen that context can be None or context.REQUEST is missing and `make_relation_root_path` is used as basepath for widget queries.