### PR TITLE
Don't show the edit button for LRF if it is locked

### DIFF
--- a/news/+lock.bugfix
+++ b/news/+lock.bugfix
@@ -1,0 +1,1 @@
+Don't show the edit button for the Language Root Folder if it is locked. @davisagli

--- a/src/plone/app/multilingual/profiles/default/types/LRF.xml
+++ b/src/plone/app/multilingual/profiles/default/types/LRF.xml
@@ -68,7 +68,7 @@
   </action>
   <action action_id="edit"
           category="object"
-          condition_expr=""
+          condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
           icon_expr="string:toolbar-action/edit"
           link_target=""
           title="Edit"


### PR DESCRIPTION
This matches what we do for other content types in plone.app.contenttypes.