### PR TITLE
Allow calling SetupMultilingualSite in any context

### DIFF
--- a/news/+setupmultilingualsite.feature
+++ b/news/+setupmultilingualsite.feature
@@ -1,1 +1,1 @@
-Allow calling SetupMultilingualSite to any folder @erral
+Allow calling SetupMultilingualSite in any folder, not only portal @erral

--- a/news/+setupmultilingualsite.feature
+++ b/news/+setupmultilingualsite.feature
@@ -1,0 +1,1 @@
+Allow calling SetupMultilingualSite to any folder @erral

--- a/src/plone/app/multilingual/browser/setup.py
+++ b/src/plone/app/multilingual/browser/setup.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_base
 from logging import getLogger
 from plone.app.dexterity.behaviors.exclfromnav import IExcludeFromNavigation
 from plone.app.multilingual import _
@@ -134,7 +135,7 @@ class SetupMultilingualSite:
         else:
             folderId = str(code)
 
-        folder = getattr(self.context, folderId, None)
+        folder = getattr(aq_base(self.context), folderId, None)
         wftool = getToolByName(self.context, "portal_workflow")
 
         assets_folder_id = translate(
@@ -294,7 +295,7 @@ class SetupMultilingualSite:
         When plone.volto is installed before plone.app.multilingual, the LRF type
         should have the volto.blocks behavior to support Volto's block-based editing.
         """
-        installer = get_installer(self.context)
+        installer = get_installer(getSite())
 
         if not installer.is_product_installed("plone.volto"):
             return

--- a/src/plone/app/multilingual/tests/test_setup.py
+++ b/src/plone/app/multilingual/tests/test_setup.py
@@ -110,6 +110,81 @@ class TestSetupMultilingualSite(unittest.TestCase):
             "LRF type should not have volto.blocks behavior without Volto",
         )
 
+    def test_call_setupsite_single_language(self):
+        """
+        When calling setupSite in a site with a single language
+        nothing is created
+        """
+        self.assertEqual(len(self.languages), 1)
+        setup_tool = SetupMultilingualSite()
+        setup_tool.setupSite(self.portal)
+        self.assertNotIn(self.languages[0], self.portal)
+
+    def test_call_setupsite_multiple_language(self):
+        """
+        When calling setupSite in a site with a multiple languages
+        the corresponding LRFs are created
+        """
+        self.language_tool.addSupportedLanguage("en")
+        self.language_tool.addSupportedLanguage("es")
+        languages = self.language_tool.getSupportedLanguages()
+
+        # Check that the newly created folder has no items in it
+        for language in languages:
+            self.assertNotIn(language, self.portal)
+
+        setup_tool = SetupMultilingualSite()
+        setup_tool.setupSite(self.portal)
+
+        for language in languages:
+            # Check that the folder has been created properly and
+            # its portal_type and language are correct
+            self.assertIn(language, self.portal)
+            lang_folder = self.portal[language]
+            self.assertEqual(lang_folder.portal_type, "LRF")
+
+    def test_call_setupsite_single_language_subfolder(self):
+        """
+        When calling setupSite in a site with a single language
+        nothing is created
+        """
+        self.assertEqual(len(self.languages), 1)
+
+        self.portal.invokeFactory(id="folder", type_name="Folder")
+        folder = self.portal["folder"]
+
+        self.assertNotIn(self.languages[0], folder)
+
+        setup_tool = SetupMultilingualSite()
+        setup_tool.setupSite(folder)
+        self.assertNotIn(self.languages[0], folder)
+
+    def test_call_setupsite_in_subfolder_multiple_languages(self):
+        """when calling setup site in a subfolder
+        recreates all the languages in that subfolder
+        """
+
+        self.language_tool.addSupportedLanguage("en")
+        self.language_tool.addSupportedLanguage("es")
+        languages = self.language_tool.getSupportedLanguages()
+
+        self.portal.invokeFactory(id="folder", type_name="Folder")
+        folder = self.portal["folder"]
+
+        # Check that the newly created folder has no items in it
+        for language in languages:
+            self.assertNotIn(language, folder)
+
+        setup_tool = SetupMultilingualSite()
+        setup_tool.setupSite(folder)
+
+        for language in languages:
+            # Check that the folder has been created properly and
+            # its portal_type and language are correct
+            self.assertIn(language, folder)
+            lang_folder = folder[language]
+            self.assertEqual(lang_folder.portal_type, "LRF")
+
 
 class TestSetupMultilingualPresetSite(unittest.TestCase):
     """Testing multilingual site with predefined languages."""

--- a/src/plone/app/multilingual/tests/test_setup.py
+++ b/src/plone/app/multilingual/tests/test_setup.py
@@ -145,7 +145,7 @@ class TestSetupMultilingualSite(unittest.TestCase):
 
     def test_call_setupsite_single_language_subfolder(self):
         """
-        When calling setupSite in a site with a single language
+        When calling setupSite in a folder of a site with a single language
         nothing is created
         """
         self.assertEqual(len(self.languages), 1)


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

This PR allows calling `SetupMultilingualSite`'s `setupSite` in any context.

In core Plone, this tool is called always with `portal`, and thus creates the `LanguageRootFolder` or `LRF`s in the root of the site. 

So far so good.

With these changes, we allow calling it in any folder. Why? When creating a subsite (for instance using [collective.lineage](https://github.com/collective/collective.lineage)) sometimes you may want to have a different language set in the subsite (for instance: `es` and `en` in the full site, but also `fr` and `de` in the subsite for the Tourism department; or the other way around).

The important change here is calling `aq_base(self.context)` when the method checks whether the `LRF` exists. In subsites, if we don't exclude acquisition from the check, it will return `True` if the `LRF` exists in the root of the site, and thus won't create the `LRF` inside the subsite.

Moreover I added some more tests to test the behavior of `setupSite`

